### PR TITLE
Subscriber method is public

### DIFF
--- a/EventBus/src/de/greenrobot/event/SubscriberMethod.java
+++ b/EventBus/src/de/greenrobot/event/SubscriberMethod.java
@@ -17,7 +17,7 @@ package de.greenrobot.event;
 
 import java.lang.reflect.Method;
 
-final class SubscriberMethod {
+final public class SubscriberMethod {
     final Method method;
     final ThreadMode threadMode;
     final Class<?> eventType;


### PR DESCRIPTION
Nevertheless EventBus is public it's hard to extend it 'cause of package-access SubscriberMethod. 
E.g. I want to extend EventBus to have a method giving me the *list of event types by subscriber:

``` java
    /**
     * Get list of registered event types for subscriber object.
     * @param subscriber
     * @return list of event types' classes which subscriber is registered on.
     */
    public List<Class<?>> getEventTypesBySubscriber(Object subscriber) {
        List<SubscriberMethod> subscriberMethods = subscriberMethodFinder.findSubscriberMethods(subscriber.getClass(), defaultMethodName);
        List<Class<?>> eventTypes = new ArrayList<Class<?>>(subscriberMethods.size());
        for (SubscriberMethod method : subscriberMethods) {
            eventTypes.add(method.eventType);
        }
        return  eventTypes;
    }
```
- used to remove sticky events in generic method `onEvent(Object o)` right after they are finally delivered.
