### PR TITLE
SubscriberMethod publicity

### DIFF
--- a/EventBus/src/de/greenrobot/event/SubscriberMethod.java
+++ b/EventBus/src/de/greenrobot/event/SubscriberMethod.java
@@ -18,9 +18,9 @@ package de.greenrobot.event;
 import java.lang.reflect.Method;
 
 final public class SubscriberMethod {
-    final Method method;
-    final ThreadMode threadMode;
-    final Class<?> eventType;
+    final public Method method;
+    final public ThreadMode threadMode;
+    final public Class<?> eventType;
     /** Used for efficient comparison */
     String methodString;
 

--- a/EventBus/src/de/greenrobot/event/SubscriberMethodFinder.java
+++ b/EventBus/src/de/greenrobot/event/SubscriberMethodFinder.java
@@ -15,6 +15,8 @@
  */
 package de.greenrobot.event;
 
+import android.util.Log;
+
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -24,14 +26,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import android.util.Log;
-
-class SubscriberMethodFinder {
+public class SubscriberMethodFinder {
     private static final int MODIFIERS_IGNORE = Modifier.ABSTRACT | Modifier.STATIC;
     private static final Map<String, List<SubscriberMethod>> methodCache = new HashMap<String, List<SubscriberMethod>>();
     private static final Map<Class<?>, Class<?>> skipMethodVerificationForClasses = new ConcurrentHashMap<Class<?>, Class<?>>();
 
-    List<SubscriberMethod> findSubscriberMethods(Class<?> subscriberClass, String eventMethodName) {
+    public List<SubscriberMethod> findSubscriberMethods(Class<?> subscriberClass, String eventMethodName) {
         String key = subscriberClass.getName() + '.' + eventMethodName;
         List<SubscriberMethod> subscriberMethods;
         synchronized (methodCache) {


### PR DESCRIPTION
Nevertheless EventBus is public it's hard to extend it 'cause of package-access SubscriberMethod. 
E.g. I want to extend EventBus to have a method giving me the *list of event types by subscriber:

``` java
    /**
     * Get list of registered event types for subscriber object.
     * @param subscriber
     * @return list of event types' classes which subscriber is registered on.
     */
    public List<Class<?>> getEventTypesBySubscriber(Object subscriber) {
        List<SubscriberMethod> subscriberMethods = subscriberMethodFinder.findSubscriberMethods(subscriber.getClass(), defaultMethodName);
        List<Class<?>> eventTypes = new ArrayList<Class<?>>(subscriberMethods.size());
        for (SubscriberMethod method : subscriberMethods) {
            eventTypes.add(method.eventType);
        }
        return  eventTypes;
    }
```
- used to remove sticky events in generic method `onEvent(Object o)` right after they are finally delivered.
