### PR TITLE
Remove redundant settings.gradle to fix Android Studio import problem

### DIFF
--- a/EventBus/settings.gradle
+++ b/EventBus/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'eventbus'


### PR DESCRIPTION
Android studio 0.4.4+ introduced strange bug: libproject import problems, for details see https://code.google.com/p/android/issues/detail?id=65915
