### PR TITLE
fix setting executionScope on event

### DIFF
--- a/EventBus/src/de/greenrobot/event/util/AsyncExecutor.java
+++ b/EventBus/src/de/greenrobot/event/util/AsyncExecutor.java
@@ -121,8 +121,8 @@ public class AsyncExecutor {
                         Log.e(EventBus.TAG, "Original exception:", e);
                         throw new RuntimeException("Could not create failure event", e1);
                     }
-                    if (e instanceof HasExecutionScope) {
-                        ((HasExecutionScope) e).setExecutionScope(scope);
+                    if (event instanceof HasExecutionScope) {
+                        ((HasExecutionScope) event).setExecutionScope(scope);
                     }
                     eventBus.post(event);
                 }


### PR DESCRIPTION
ExecutionScope on FailureEvent was always null because it was tried to set on the exception instead of the failureEvent.
