### PR TITLE
BackgroudPoster can post thread more then one time

### DIFF
--- a/EventBus/src/de/greenrobot/event/PendingPostQueue.java
+++ b/EventBus/src/de/greenrobot/event/PendingPostQueue.java
@@ -37,4 +37,7 @@ final class PendingPostQueue {
         return poll();
     }
 
+    synchronized boolean hasData() {
+        return head != null;
+    }
 }


### PR DESCRIPTION
Outer try/catch block can break post logic.
Steps:
BG thread execute
"return" inside synchronized block, but not execute finally block. So
executorRunning is false.
An other thread are in synchronized block of
enqueue, check executorRunning (it is false) and make it true.
Then BG
thread execute finally section and changes executorRunning to false.
So
any other calls to enqueue will start this runnable again in
executor.
This pull request fixes this bug and restart thread if it ends
by interrupt.
