### PR TITLE
StickyEvent unregister/register delivery bug

### DIFF
--- a/EventBus/src/de/greenrobot/event/EventBus.java
+++ b/EventBus/src/de/greenrobot/event/EventBus.java
@@ -278,14 +278,20 @@ public class EventBus {
         subscribedEvents.add(eventType);
 
         if (sticky) {
-            Object stickyEvent;
+            final List<Object> registeredStickyEvents = new ArrayList<Object>();
             synchronized (stickyEvents) {
-                stickyEvent = stickyEvents.get(eventType);
+                for (final Map.Entry<Class<?>, Object> stickyEventClasses : stickyEvents.entrySet()) {
+                    if (stickyEventClasses.getKey().isAssignableFrom(eventType)) {
+                        registeredStickyEvents.add(stickyEventClasses.getValue());
+                    }
+                }
             }
-            if (stickyEvent != null) {
-                // If the subscriber is trying to abort the event, it will fail (event is not tracked in posting state)
-                // --> Strange corner case, which we don't take care of here.
-                postToSubscription(newSubscription, stickyEvent, Looper.getMainLooper() == Looper.myLooper());
+            for(final Object stickyEvent : registeredStickyEvents) {
+                if (stickyEvent != null) {
+                    // If the subscriber is trying to abort the event, it will fail (event is not tracked in posting state)
+                    // --> Strange corner case, which we don't take care of here.
+                    postToSubscription(newSubscription, stickyEvent, Looper.getMainLooper() == Looper.myLooper());
+                }
             }
         }
     }


### PR DESCRIPTION
This issue exists in this case:
We have class A and its subclass B.
In
class BaseClass we have method "onEvent(A a)".
When we execute method
"postStick(new B())".
If BaseClass was registered, then its onEvent
method executes (it is
ok).
But if this class wasn't registered or call
unregister and then
registerSticky, then it will not receive event at
all. This is bug.
