### PR TITLE
Replace `getMethods()` with `getDeclaredMethods()`

### DIFF
--- a/EventBus/src/de/greenrobot/event/SubscriberMethodFinder.java
+++ b/EventBus/src/de/greenrobot/event/SubscriberMethodFinder.java
@@ -52,7 +52,7 @@ class SubscriberMethodFinder {
             }
 
             // Starting with EventBus 2.2 we enforced methods to be public (might change with annotations again)
-            Method[] methods = clazz.getMethods();
+            Method[] methods = clazz.getDeclaredMethods();
             for (Method method : methods) {
                 String methodName = method.getName();
                 if (methodName.startsWith(eventMethodName)) {


### PR DESCRIPTION
- The while-loop loops through all the parents.
- `Class.getMethods()` gets all the methods from all superclasses.
  So basicly we are doing things twice here.

When extending from Activity (or another Android framework class), this means that `getMethods()` will return all methods of all superclasses (multiple times because of the while-loop), so that's a lot of redundant string-comparison.
