### PR TITLE
Sending NoSubscriberEvent when subscription is not active.

### DIFF
--- a/EventBus/src/de/greenrobot/event/EventBus.java
+++ b/EventBus/src/de/greenrobot/event/EventBus.java
@@ -561,6 +561,8 @@ public class EventBus {
         PendingPost.releasePendingPost(pendingPost);
         if (subscription.active) {
             invokeSubscriber(subscription, event);
+        } else {
+            post(new NoSubscriberEvent(this, event));
         }
     }
 


### PR DESCRIPTION
When sending an event from a background thread to the main thread and at the same time the subscription is unregistered a NoSubscriberEvent should be sent.

In this case the subscription.active is "false" and no notification is sent.
