### PR TITLE
fix can't display <init> tag in HOWTO.md #141

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -186,7 +186,9 @@ It's also possible to remove previously posted sticky events using one of the re
 ProGuard configuration
 ----------------------
 ProGuard obfuscates method names. However, the onEvent methods must not renamed because they are accessed using reflection. Use the following snip in your ProGuard configuration file (proguard.cfg):
-<pre><code>-keepclassmembers class ** {
+
+```
+-keepclassmembers class ** {
     public void onEvent*(**);
 }
 
@@ -194,7 +196,7 @@ ProGuard obfuscates method names. However, the onEvent methods must not renamed 
 -keepclassmembers class * extends de.greenrobot.event.util.ThrowableFailureEvent {
     <init>(java.lang.Throwable);
 }
-</code></pre>
+```
 
 
 AsyncExecutor


### PR DESCRIPTION
<pre><code> will didn't display <init> in content.