### PR TITLE
Improve singleton initialization

### DIFF
--- a/EventBus/src/de/greenrobot/event/EventBus.java
+++ b/EventBus/src/de/greenrobot/event/EventBus.java
@@ -42,7 +42,9 @@ public class EventBus {
     /** Log tag, apps may override it. */
     public static String TAG = "Event";
 
-    static volatile EventBus defaultInstance;
+    private static class EventBusHolder {
+        public static EventBus eventBus = new EventBus();
+    }
 
     private static final EventBusBuilder DEFAULT_BUILDER = new EventBusBuilder();
     private static final Map<Class<?>, List<Class<?>>> eventTypesCache = new HashMap<Class<?>, List<Class<?>>>();
@@ -74,14 +76,7 @@ public class EventBus {
 
     /** Convenience singleton for apps using a process-wide EventBus instance. */
     public static EventBus getDefault() {
-        if (defaultInstance == null) {
-            synchronized (EventBus.class) {
-                if (defaultInstance == null) {
-                    defaultInstance = new EventBus();
-                }
-            }
-        }
-        return defaultInstance;
+        return EventBusHolder.eventBus;
     }
 
     public static EventBusBuilder builder() {


### PR DESCRIPTION
According to [1] double-checked locking when used with a volatile member
is no longer broken since Java5 but it still is not best practice for
singleton initialization.

The proposed solution is a static holder class which delegates the lazy
initialization to the class loader.

1) Section "Does this fix the double-checked locking problem" of
http://www.ibm.com/developerworks/library/j-jtp03304/