### PR TITLE
Fix two common needs

### DIFF
--- a/EventBus/src/de/greenrobot/event/EventBus.java
+++ b/EventBus/src/de/greenrobot/event/EventBus.java
@@ -19,6 +19,7 @@ import android.os.Looper;
 import android.util.Log;
 
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -161,9 +162,16 @@ public class EventBus {
     }
 
     private synchronized void register(Object subscriber, boolean sticky, int priority) {
-        List<SubscriberMethod> subscriberMethods = subscriberMethodFinder.findSubscriberMethods(subscriber.getClass());
+        boolean staticRegister = subscriber.getClass().equals(Class.class);
+        Class clazz = staticRegister ? (Class) subscriber : subscriber.getClass();
+        List<SubscriberMethod> subscriberMethods = subscriberMethodFinder.findSubscriberMethods(clazz);
+
         for (SubscriberMethod subscriberMethod : subscriberMethods) {
-            subscribe(subscriber, subscriberMethod, sticky, priority);
+            if (staticRegister && (subscriberMethod.method.getModifiers() & Modifier.STATIC) != 0) {
+                subscribe(subscriber, subscriberMethod, sticky, priority);
+            } else if (!staticRegister) {
+                subscribe(subscriber, subscriberMethod, sticky, priority);
+            }
         }
     }
 
@@ -177,8 +185,9 @@ public class EventBus {
             subscriptionsByEventType.put(eventType, subscriptions);
         } else {
             if (subscriptions.contains(newSubscription)) {
-                Log.i(TAG, "Subscriber " + subscriber.getClass() + " already registered to event "
-                        + eventType);
+                Log.i(TAG, "Subscriber " + ((subscriber instanceof Class) ?
+                                subscriber : subscriber.getClass()) +
+                                " already registered to event " + eventType);
             }
         }
 

--- a/EventBus/src/de/greenrobot/event/EventBus.java
+++ b/EventBus/src/de/greenrobot/event/EventBus.java
@@ -177,7 +177,7 @@ public class EventBus {
             subscriptionsByEventType.put(eventType, subscriptions);
         } else {
             if (subscriptions.contains(newSubscription)) {
-                throw new EventBusException("Subscriber " + subscriber.getClass() + " already registered to event "
+                Log.i(TAG, "Subscriber " + subscriber.getClass() + " already registered to event "
                         + eventType);
             }
         }

--- a/EventBus/src/de/greenrobot/event/SubscriberMethodFinder.java
+++ b/EventBus/src/de/greenrobot/event/SubscriberMethodFinder.java
@@ -36,7 +36,8 @@ class SubscriberMethodFinder {
     private static final int BRIDGE = 0x40;
     private static final int SYNTHETIC = 0x1000;
 
-    private static final int MODIFIERS_IGNORE = Modifier.ABSTRACT | Modifier.STATIC | BRIDGE | SYNTHETIC;
+    //delete Modifier.STATIC
+    private static final int MODIFIERS_IGNORE = Modifier.ABSTRACT | BRIDGE | SYNTHETIC;
     private static final Map<Class<?>, List<SubscriberMethod>> methodCache = new HashMap<Class<?>, List<SubscriberMethod>>();
 
     private final Map<Class<?>, Class<?>> skipMethodVerificationForClasses;


### PR DESCRIPTION
Hi all,
there are two needs during the using of EventBus.
1. Because of the complex lifecycle of activities, fragments, and so on, we offten need to register the same object again. But it's not allowed in EventBus.
2. We have some tool class, only provide some static method, currently it's not support in EventBus.

I add these two functions, pls help have a review.
