### PR TITLE
Don't throw exception for absence public methods with the @Subscribe annotation if throwSubscriberException=false

### DIFF
--- a/EventBus/src/org/greenrobot/eventbus/EventBus.java
+++ b/EventBus/src/org/greenrobot/eventbus/EventBus.java
@@ -113,7 +113,7 @@ public class EventBus {
         asyncPoster = new AsyncPoster(this);
         indexCount = builder.subscriberInfoIndexes != null ? builder.subscriberInfoIndexes.size() : 0;
         subscriberMethodFinder = new SubscriberMethodFinder(builder.subscriberInfoIndexes,
-                builder.strictMethodVerification, builder.ignoreGeneratedIndex);
+                builder.strictMethodVerification, builder.ignoreGeneratedIndex, builder.throwSubscriberException);
         logSubscriberExceptions = builder.logSubscriberExceptions;
         logNoSubscriberMessages = builder.logNoSubscriberMessages;
         sendSubscriberExceptionEvent = builder.sendSubscriberExceptionEvent;

--- a/EventBus/src/org/greenrobot/eventbus/SubscriberMethodFinder.java
+++ b/EventBus/src/org/greenrobot/eventbus/SubscriberMethodFinder.java
@@ -41,15 +41,17 @@ class SubscriberMethodFinder {
     private List<SubscriberInfoIndex> subscriberInfoIndexes;
     private final boolean strictMethodVerification;
     private final boolean ignoreGeneratedIndex;
+    private final boolean throwSubscriberException;
 
     private static final int POOL_SIZE = 4;
     private static final FindState[] FIND_STATE_POOL = new FindState[POOL_SIZE];
 
     SubscriberMethodFinder(List<SubscriberInfoIndex> subscriberInfoIndexes, boolean strictMethodVerification,
-                           boolean ignoreGeneratedIndex) {
+                           boolean ignoreGeneratedIndex, boolean throwSubscriberException) {
         this.subscriberInfoIndexes = subscriberInfoIndexes;
         this.strictMethodVerification = strictMethodVerification;
         this.ignoreGeneratedIndex = ignoreGeneratedIndex;
+        this.throwSubscriberException = throwSubscriberException;
     }
 
     List<SubscriberMethod> findSubscriberMethods(Class<?> subscriberClass) {
@@ -63,7 +65,7 @@ class SubscriberMethodFinder {
         } else {
             subscriberMethods = findUsingInfo(subscriberClass);
         }
-        if (subscriberMethods.isEmpty()) {
+        if (subscriberMethods.isEmpty() && throwSubscriberException) {
             throw new EventBusException("Subscriber " + subscriberClass
                     + " and its super classes have no public methods with the @Subscribe annotation");
         } else {


### PR DESCRIPTION
It is so unexpected when `throwSubscriberException=false ` but it still crashing if there is no subscribers. In my case it happened in base fragment's class and I was really confused when realized that I can't disable this kind of check.