### PR TITLE
Fixed a java.lang.NoClassDefFoundError exception on some device

### DIFF
--- a/EventBus/src/org/greenrobot/eventbus/meta/AbstractSubscriberInfo.java
+++ b/EventBus/src/org/greenrobot/eventbus/meta/AbstractSubscriberInfo.java
@@ -67,7 +67,14 @@ public abstract class AbstractSubscriberInfo implements SubscriberInfo {
     protected SubscriberMethod createSubscriberMethod(String methodName, Class<?> eventType, ThreadMode threadMode,
                                                       int priority, boolean sticky) {
         try {
-            Method method = subscriberClass.getDeclaredMethod(methodName, eventType);
+            Method method;
+            try {
+                method = subscriberClass.getDeclaredMethod(methodName, eventType);
+            } catch (Throwable th) {
+                // Workaround for java.lang.NoClassDefFoundError, see https://github.com/greenrobot/EventBus/issues/149
+                method = subscriberClass.getMethod(methodName, eventType);
+            }
+
             return new SubscriberMethod(method, eventType, threadMode, priority, sticky);
         } catch (NoSuchMethodException e) {
             throw new EventBusException("Could not find subscriber method in " + subscriberClass +


### PR DESCRIPTION
Hello,

An error similar to [https://github.com/greenrobot/EventBus/issues/149](https://github.com/greenrobot/EventBus/issues/149) occurs on some Android 4.1 devices when the Index class is loaded.

This should solve the issue.

Benjamin