### PR TITLE
Make EventBus(EventBusBuilder) constructor public.

### DIFF
--- a/EventBus/src/org/greenrobot/eventbus/EventBus.java
+++ b/EventBus/src/org/greenrobot/eventbus/EventBus.java
@@ -104,7 +104,7 @@ public class EventBus {
         this(DEFAULT_BUILDER);
     }
 
-    EventBus(EventBusBuilder builder) {
+    public EventBus(EventBusBuilder builder) {
         subscriptionsByEventType = new HashMap<>();
         typesBySubscriber = new HashMap<>();
         stickyEvents = new ConcurrentHashMap<>();


### PR DESCRIPTION
There are scenarios when it is better to use EventBus as base class. In this case it is impossible to construct custom class which is configured by EventBusBuilder builder.
This PR makes the `EventBus(EventBusBuilder)` constructor public to support latter case.