### PR TITLE
Added ThreadMode.MAIN_ASYNC to queue event delivery for a future loop of the Main UI Thread.

### DIFF
--- a/EventBus/src/org/greenrobot/eventbus/EventBus.java
+++ b/EventBus/src/org/greenrobot/eventbus/EventBus.java
@@ -422,6 +422,9 @@ public class EventBus {
                     mainThreadPoster.enqueue(subscription, event);
                 }
                 break;
+            case MAIN_ASYNC:
+                mainThreadPoster.enqueue(subscription, event);
+                break;
             case BACKGROUND:
                 if (isMainThread) {
                     backgroundPoster.enqueue(subscription, event);

--- a/EventBus/src/org/greenrobot/eventbus/ThreadMode.java
+++ b/EventBus/src/org/greenrobot/eventbus/ThreadMode.java
@@ -39,6 +39,12 @@ public enum ThreadMode {
     MAIN,
 
     /**
+     * Event will be queued for delivery and the subscriber will be called in Android's main thread (sometimes referred to as UI thread).
+     * This ensures that the poster does not block and that the subscriber is called by Android's main thread so can update UI.
+     */
+    MAIN_ASYNC,
+
+    /**
      * Subscriber will be called in a background thread. If posting thread is not the main thread, event handler methods
      * will be called directly in the posting thread. If the posting thread is the main thread, EventBus uses a single
      * background thread, that will deliver all its events sequentially. Event handlers using this mode should try to


### PR DESCRIPTION
Added ThreadMode.MAIN_ASYNC to allow a subscriber to declare that it wants to be called in the Main UI thread but the event should be queued for delivery by a future Main UI loop.

 Ie MAIN_ASYNC subscribers never received delivery directly from the poster's thread, even if it is the Main UI thread.

This ensures that events sent to MAIN_ASYNC subscribers are delivered in the order in which they are posted, regardless of the poster's thread. Extremely useful for ensuring that events that denote steps in a process (eg beginning, end) and are used to present UI state are delivered in the order in which they are created.

This is a solution for #307 that allows existing behaviour to continue.