### PR TITLE
#284 - Allow registration of classes without any subscriptions

### DIFF
--- a/EventBus/src/org/greenrobot/eventbus/EventBus.java
+++ b/EventBus/src/org/greenrobot/eventbus/EventBus.java
@@ -113,7 +113,7 @@ public class EventBus {
         asyncPoster = new AsyncPoster(this);
         indexCount = builder.subscriberInfoIndexes != null ? builder.subscriberInfoIndexes.size() : 0;
         subscriberMethodFinder = new SubscriberMethodFinder(builder.subscriberInfoIndexes,
-                builder.strictMethodVerification, builder.ignoreGeneratedIndex);
+                builder.strictMethodVerification, builder.ignoreGeneratedIndex, builder.throwNoSubscribersException);
         logSubscriberExceptions = builder.logSubscriberExceptions;
         logNoSubscriberMessages = builder.logNoSubscriberMessages;
         sendSubscriberExceptionEvent = builder.sendSubscriberExceptionEvent;

--- a/EventBus/src/org/greenrobot/eventbus/EventBusBuilder.java
+++ b/EventBus/src/org/greenrobot/eventbus/EventBusBuilder.java
@@ -36,6 +36,7 @@ public class EventBusBuilder {
     boolean throwSubscriberException;
     boolean eventInheritance = true;
     boolean ignoreGeneratedIndex;
+    boolean throwNoSubscribersException;
     boolean strictMethodVerification;
     ExecutorService executorService = DEFAULT_EXECUTOR_SERVICE;
     List<Class<?>> skipMethodVerificationForClasses;
@@ -119,6 +120,12 @@ public class EventBusBuilder {
     /** Forces the use of reflection even if there's a generated index (default: false). */
     public EventBusBuilder ignoreGeneratedIndex(boolean ignoreGeneratedIndex) {
         this.ignoreGeneratedIndex = ignoreGeneratedIndex;
+        return this;
+    }
+
+    /** Ignore when registered class have no subscribers (default: false). */
+    public EventBusBuilder throwNoSubscribersException(boolean throwNoSubscribersException) {
+        this.throwNoSubscribersException = throwNoSubscribersException;
         return this;
     }
 

--- a/EventBus/src/org/greenrobot/eventbus/EventBusBuilder.java
+++ b/EventBus/src/org/greenrobot/eventbus/EventBusBuilder.java
@@ -33,10 +33,10 @@ public class EventBusBuilder {
     boolean logNoSubscriberMessages = true;
     boolean sendSubscriberExceptionEvent = true;
     boolean sendNoSubscriberEvent = true;
-    boolean throwSubscriberException;
+    boolean throwNoSubscribersException = true;
+    boolean throwSubscriberException = false;
     boolean eventInheritance = true;
     boolean ignoreGeneratedIndex;
-    boolean throwNoSubscribersException;
     boolean strictMethodVerification;
     ExecutorService executorService = DEFAULT_EXECUTOR_SERVICE;
     List<Class<?>> skipMethodVerificationForClasses;
@@ -80,6 +80,13 @@ public class EventBusBuilder {
         return this;
     }
 
+
+    /** Ignore when registered class have no subscribers (default: true). */
+    public EventBusBuilder throwNoSubscribersException(boolean throwNoSubscribersException) {
+        this.throwNoSubscribersException = throwNoSubscribersException;
+        return this;
+    }
+
     /**
      * By default, EventBus considers the event class hierarchy (subscribers to super classes will be notified).
      * Switching this feature off will improve posting of events. For simple event classes extending Object directly,
@@ -120,12 +127,6 @@ public class EventBusBuilder {
     /** Forces the use of reflection even if there's a generated index (default: false). */
     public EventBusBuilder ignoreGeneratedIndex(boolean ignoreGeneratedIndex) {
         this.ignoreGeneratedIndex = ignoreGeneratedIndex;
-        return this;
-    }
-
-    /** Ignore when registered class have no subscribers (default: false). */
-    public EventBusBuilder throwNoSubscribersException(boolean throwNoSubscribersException) {
-        this.throwNoSubscribersException = throwNoSubscribersException;
         return this;
     }
 

--- a/EventBus/src/org/greenrobot/eventbus/SubscriberMethodFinder.java
+++ b/EventBus/src/org/greenrobot/eventbus/SubscriberMethodFinder.java
@@ -39,6 +39,7 @@ class SubscriberMethodFinder {
     private static final Map<Class<?>, List<SubscriberMethod>> METHOD_CACHE = new ConcurrentHashMap<>();
 
     private List<SubscriberInfoIndex> subscriberInfoIndexes;
+    private final boolean throwNoSubscribersException;
     private final boolean strictMethodVerification;
     private final boolean ignoreGeneratedIndex;
 
@@ -46,10 +47,11 @@ class SubscriberMethodFinder {
     private static final FindState[] FIND_STATE_POOL = new FindState[POOL_SIZE];
 
     SubscriberMethodFinder(List<SubscriberInfoIndex> subscriberInfoIndexes, boolean strictMethodVerification,
-                           boolean ignoreGeneratedIndex) {
+                           boolean ignoreGeneratedIndex, boolean throwNoSubscribersException) {
         this.subscriberInfoIndexes = subscriberInfoIndexes;
         this.strictMethodVerification = strictMethodVerification;
         this.ignoreGeneratedIndex = ignoreGeneratedIndex;
+        this.throwNoSubscribersException = throwNoSubscribersException;
     }
 
     List<SubscriberMethod> findSubscriberMethods(Class<?> subscriberClass) {
@@ -63,7 +65,7 @@ class SubscriberMethodFinder {
         } else {
             subscriberMethods = findUsingInfo(subscriberClass);
         }
-        if (subscriberMethods.isEmpty()) {
+        if (throwNoSubscribersException && subscriberMethods.isEmpty()) {
             throw new EventBusException("Subscriber " + subscriberClass
                     + " and its super classes have no public methods with the @Subscribe annotation");
         } else {

--- a/EventBusPerformance/build.gradle
+++ b/EventBusPerformance/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:2.1.2'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
     }
 }
@@ -30,7 +30,7 @@ apt {
 
 android {
     buildToolsVersion '23.0.2' // When updating, don't forget to adjust .travis.yml
-    compileSdkVersion 19
+    compileSdkVersion 23
 
     sourceSets {
         main {

--- a/EventBusTest/build.gradle
+++ b/EventBusTest/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:2.1.2'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
     }
 }
@@ -28,7 +28,7 @@ dependencies {
 
 android {
     buildToolsVersion '23.0.2' // When updating, don't forget to adjust .travis.yml
-    compileSdkVersion 19
+    compileSdkVersion 23
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_7

--- a/build.gradle
+++ b/build.gradle
@@ -7,5 +7,5 @@ if (JavaVersion.current().isJava8Compatible()) {
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '2.10'
+    gradleVersion = '2.14'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-all.zip


### PR DESCRIPTION
Add EventBusBuilder.throwNoSubscribersException(boolean throwNoSubscribersException) to allow objects to register in the EventBus without subscribing to any event.

This allows, for example, to register on a base class, without having to replicate the registering logic in all sub-classes.

This implements the feature requested at #284.
