### PR TITLE
Reflection-less Index generation [Upto 70% improvement in performance]

### DIFF
--- a/EventBus/src/org/greenrobot/eventbus/EventBus.java
+++ b/EventBus/src/org/greenrobot/eventbus/EventBus.java
@@ -133,6 +133,7 @@ public class EventBus {
      */
     public void register(Object subscriber) {
         Class<?> subscriberClass = subscriber.getClass();
+
         List<SubscriberMethod> subscriberMethods = subscriberMethodFinder.findSubscriberMethods(subscriberClass);
         synchronized (this) {
             for (SubscriberMethod subscriberMethod : subscriberMethods) {
@@ -482,7 +483,7 @@ public class EventBus {
 
     void invokeSubscriber(Subscription subscription, Object event) {
         try {
-            subscription.subscriberMethod.method.invoke(subscription.subscriber, event);
+            subscription.subscriberMethod.invoke(subscription.subscriber, event);
         } catch (InvocationTargetException e) {
             handleSubscriberException(subscription, event, e.getCause());
         } catch (IllegalAccessException e) {

--- a/EventBus/src/org/greenrobot/eventbus/GeneratedSubscriberMethod.java
+++ b/EventBus/src/org/greenrobot/eventbus/GeneratedSubscriberMethod.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2012-2016 Markus Junginger, greenrobot (http://greenrobot.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.greenrobot.eventbus;
+
+import org.greenrobot.eventbus.meta.SubscriberMethodInvoker;
+
+import java.lang.reflect.InvocationTargetException;
+
+/** Used internally by EventBus for generated index */
+public class GeneratedSubscriberMethod extends SubscriberMethod{
+
+    final SubscriberMethodInvoker invoker;
+    final String methodName;
+    final Class<?> declaringClass;
+
+    public GeneratedSubscriberMethod(SubscriberMethodInvoker invoker, String methodName, Class<?> declaringClass, Class<?> eventType, ThreadMode threadMode, int priority, boolean sticky) {
+        super(eventType, threadMode, priority, sticky);
+        this.invoker = invoker;
+        this.methodName = methodName;
+        this.declaringClass = declaringClass;
+    }
+
+    @Override
+    public void invoke(Object subscriber, Object event) throws InvocationTargetException, IllegalAccessException {
+        invoker.invoke(subscriber, event);
+    }
+
+    @Override
+    public String getName() {
+        return methodName;
+    }
+
+    @Override
+    public Class<?> getDeclaringClass() {
+        return declaringClass;
+    }
+
+    @Override
+    public int hashCode() {
+        return this.methodString.hashCode();
+    }
+}

--- a/EventBus/src/org/greenrobot/eventbus/ReflectiveSubscriberMethod.java
+++ b/EventBus/src/org/greenrobot/eventbus/ReflectiveSubscriberMethod.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2012-2016 Markus Junginger, greenrobot (http://greenrobot.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.greenrobot.eventbus;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/** Used internally by EventBus */
+public class ReflectiveSubscriberMethod extends SubscriberMethod{
+    final Method method;
+
+    public ReflectiveSubscriberMethod(Method method, Class<?> eventType, ThreadMode threadMode, int priority, boolean sticky) {
+        super(eventType, threadMode, priority, sticky);
+        this.method = method;
+    }
+
+    @Override
+    public void invoke(Object subscriber, Object event) throws InvocationTargetException, IllegalAccessException {
+        method.invoke(subscriber, event);
+    }
+
+
+    @Override
+    public String getName() {
+        return method.getName();
+    }
+
+    @Override
+    public Class<?> getDeclaringClass() {
+        return method.getDeclaringClass();
+    }
+
+    @Override
+    public int hashCode() {
+        return method.hashCode();
+    }
+}

--- a/EventBus/src/org/greenrobot/eventbus/SubscriberMethod.java
+++ b/EventBus/src/org/greenrobot/eventbus/SubscriberMethod.java
@@ -15,11 +15,10 @@
  */
 package org.greenrobot.eventbus;
 
-import java.lang.reflect.Method;
+import java.lang.reflect.InvocationTargetException;
 
 /** Used internally by EventBus and generated subscriber indexes. */
-public class SubscriberMethod {
-    final Method method;
+public abstract class SubscriberMethod {
     final ThreadMode threadMode;
     final Class<?> eventType;
     final int priority;
@@ -27,8 +26,7 @@ public class SubscriberMethod {
     /** Used for efficient comparison */
     String methodString;
 
-    public SubscriberMethod(Method method, Class<?> eventType, ThreadMode threadMode, int priority, boolean sticky) {
-        this.method = method;
+    public SubscriberMethod(Class<?> eventType, ThreadMode threadMode, int priority, boolean sticky) {
         this.threadMode = threadMode;
         this.eventType = eventType;
         this.priority = priority;
@@ -54,15 +52,18 @@ public class SubscriberMethod {
         if (methodString == null) {
             // Method.toString has more overhead, just take relevant parts of the method
             StringBuilder builder = new StringBuilder(64);
-            builder.append(method.getDeclaringClass().getName());
-            builder.append('#').append(method.getName());
+            builder.append(getDeclaringClass().getName());
+            builder.append('#').append(getName());
             builder.append('(').append(eventType.getName());
             methodString = builder.toString();
         }
     }
 
-    @Override
-    public int hashCode() {
-        return method.hashCode();
-    }
+
+    public abstract void invoke(Object subscriber, Object event) throws InvocationTargetException, IllegalAccessException;
+
+
+    public abstract String getName();
+
+    public abstract Class<?> getDeclaringClass();
 }

--- a/EventBus/src/org/greenrobot/eventbus/meta/AbstractSubscriberInfo.java
+++ b/EventBus/src/org/greenrobot/eventbus/meta/AbstractSubscriberInfo.java
@@ -58,9 +58,5 @@ public abstract class AbstractSubscriberInfo implements SubscriberInfo {
         return shouldCheckSuperclass;
     }
 
-    protected SubscriberMethod createSubscriberMethod(SubscriberMethodInvoker invoker, String methodName, Class<?> eventType, ThreadMode threadMode,
-                                                      int priority, boolean sticky) {
-        return new GeneratedSubscriberMethod(invoker, methodName, getSubscriberClass(), eventType, threadMode, priority, sticky);
-    }
 
 }

--- a/EventBus/src/org/greenrobot/eventbus/meta/AbstractSubscriberInfo.java
+++ b/EventBus/src/org/greenrobot/eventbus/meta/AbstractSubscriberInfo.java
@@ -16,6 +16,8 @@
 package org.greenrobot.eventbus.meta;
 
 import org.greenrobot.eventbus.EventBusException;
+import org.greenrobot.eventbus.GeneratedSubscriberMethod;
+import org.greenrobot.eventbus.ReflectiveSubscriberMethod;
 import org.greenrobot.eventbus.SubscriberMethod;
 import org.greenrobot.eventbus.ThreadMode;
 
@@ -56,23 +58,9 @@ public abstract class AbstractSubscriberInfo implements SubscriberInfo {
         return shouldCheckSuperclass;
     }
 
-    protected SubscriberMethod createSubscriberMethod(String methodName, Class<?> eventType) {
-        return createSubscriberMethod(methodName, eventType, ThreadMode.POSTING, 0, false);
-    }
-
-    protected SubscriberMethod createSubscriberMethod(String methodName, Class<?> eventType, ThreadMode threadMode) {
-        return createSubscriberMethod(methodName, eventType, threadMode, 0, false);
-    }
-
-    protected SubscriberMethod createSubscriberMethod(String methodName, Class<?> eventType, ThreadMode threadMode,
+    protected SubscriberMethod createSubscriberMethod(SubscriberMethodInvoker invoker, String methodName, Class<?> declaringClass, Class<?> eventType, ThreadMode threadMode,
                                                       int priority, boolean sticky) {
-        try {
-            Method method = subscriberClass.getDeclaredMethod(methodName, eventType);
-            return new SubscriberMethod(method, eventType, threadMode, priority, sticky);
-        } catch (NoSuchMethodException e) {
-            throw new EventBusException("Could not find subscriber method in " + subscriberClass +
-                    ". Maybe a missing ProGuard rule?", e);
-        }
+        return new GeneratedSubscriberMethod(invoker, methodName, declaringClass, eventType, threadMode, priority, sticky);
     }
 
 }

--- a/EventBus/src/org/greenrobot/eventbus/meta/AbstractSubscriberInfo.java
+++ b/EventBus/src/org/greenrobot/eventbus/meta/AbstractSubscriberInfo.java
@@ -58,9 +58,9 @@ public abstract class AbstractSubscriberInfo implements SubscriberInfo {
         return shouldCheckSuperclass;
     }
 
-    protected SubscriberMethod createSubscriberMethod(SubscriberMethodInvoker invoker, String methodName, Class<?> declaringClass, Class<?> eventType, ThreadMode threadMode,
+    protected SubscriberMethod createSubscriberMethod(SubscriberMethodInvoker invoker, String methodName, Class<?> eventType, ThreadMode threadMode,
                                                       int priority, boolean sticky) {
-        return new GeneratedSubscriberMethod(invoker, methodName, declaringClass, eventType, threadMode, priority, sticky);
+        return new GeneratedSubscriberMethod(invoker, methodName, getSubscriberClass(), eventType, threadMode, priority, sticky);
     }
 
 }

--- a/EventBus/src/org/greenrobot/eventbus/meta/SimpleSubscriberInfo.java
+++ b/EventBus/src/org/greenrobot/eventbus/meta/SimpleSubscriberInfo.java
@@ -35,7 +35,7 @@ public class SimpleSubscriberInfo extends AbstractSubscriberInfo {
         SubscriberMethod[] methods = new SubscriberMethod[length];
         for (int i = 0; i < length; i++) {
             SubscriberMethodInfo info = methodInfos[i];
-            methods[i] = createSubscriberMethod(info.invoker, info.methodString, info.declaringClass, info.eventType, info.threadMode,
+            methods[i] = createSubscriberMethod(info.invoker, info.methodString, info.eventType, info.threadMode,
                     info.priority, info.sticky);
         }
         return methods;

--- a/EventBus/src/org/greenrobot/eventbus/meta/SimpleSubscriberInfo.java
+++ b/EventBus/src/org/greenrobot/eventbus/meta/SimpleSubscriberInfo.java
@@ -15,7 +15,9 @@
  */
 package org.greenrobot.eventbus.meta;
 
+import org.greenrobot.eventbus.GeneratedSubscriberMethod;
 import org.greenrobot.eventbus.SubscriberMethod;
+import org.greenrobot.eventbus.ThreadMode;
 
 /**
  * Uses {@link SubscriberMethodInfo} objects to create {@link org.greenrobot.eventbus.SubscriberMethod} objects on demand.
@@ -39,5 +41,10 @@ public class SimpleSubscriberInfo extends AbstractSubscriberInfo {
                     info.priority, info.sticky);
         }
         return methods;
+    }
+
+    protected SubscriberMethod createSubscriberMethod(SubscriberMethodInvoker invoker, String methodName, Class<?> eventType, ThreadMode threadMode,
+                                                      int priority, boolean sticky) {
+        return new GeneratedSubscriberMethod(invoker, methodName, getSubscriberClass(), eventType, threadMode, priority, sticky);
     }
 }

--- a/EventBus/src/org/greenrobot/eventbus/meta/SimpleSubscriberInfo.java
+++ b/EventBus/src/org/greenrobot/eventbus/meta/SimpleSubscriberInfo.java
@@ -35,7 +35,7 @@ public class SimpleSubscriberInfo extends AbstractSubscriberInfo {
         SubscriberMethod[] methods = new SubscriberMethod[length];
         for (int i = 0; i < length; i++) {
             SubscriberMethodInfo info = methodInfos[i];
-            methods[i] = createSubscriberMethod(info.methodName, info.eventType, info.threadMode,
+            methods[i] = createSubscriberMethod(info.invoker, info.methodString, info.declaringClass, info.eventType, info.threadMode,
                     info.priority, info.sticky);
         }
         return methods;

--- a/EventBus/src/org/greenrobot/eventbus/meta/SubscriberMethodInfo.java
+++ b/EventBus/src/org/greenrobot/eventbus/meta/SubscriberMethodInfo.java
@@ -20,7 +20,6 @@ import org.greenrobot.eventbus.ThreadMode;
 public class SubscriberMethodInfo {
     final SubscriberMethodInvoker invoker;
     final String methodString;
-    final Class<?> declaringClass;
     final ThreadMode threadMode;
     final Class<?> eventType;
     final int priority;
@@ -28,12 +27,10 @@ public class SubscriberMethodInfo {
 
     public SubscriberMethodInfo(SubscriberMethodInvoker invoker,
                                 String methodString,
-                                Class<?> declaringClass,
                                 Class<?> eventType, ThreadMode threadMode,
                                 int priority, boolean sticky) {
         this.invoker = invoker;
         this.methodString = methodString;
-        this.declaringClass = declaringClass;
         this.threadMode = threadMode;
         this.eventType = eventType;
         this.priority = priority;
@@ -42,13 +39,12 @@ public class SubscriberMethodInfo {
 
     public SubscriberMethodInfo(SubscriberMethodInvoker invoker,
                                 String methodString,
-                                Class<?> declaringClass,
                                 Class<?> eventType) {
-        this(invoker, methodString, declaringClass, eventType, ThreadMode.POSTING, 0, false);
+        this(invoker, methodString, eventType, ThreadMode.POSTING, 0, false);
     }
 
-    public SubscriberMethodInfo(SubscriberMethodInvoker invoker, String methodString, Class<?> declaringClass, Class<?> eventType, ThreadMode threadMode) {
-        this(invoker, methodString, declaringClass, eventType, threadMode, 0, false);
+    public SubscriberMethodInfo(SubscriberMethodInvoker invoker, String methodString, Class<?> eventType, ThreadMode threadMode) {
+        this(invoker, methodString, eventType, threadMode, 0, false);
     }
 
 }

--- a/EventBus/src/org/greenrobot/eventbus/meta/SubscriberMethodInfo.java
+++ b/EventBus/src/org/greenrobot/eventbus/meta/SubscriberMethodInfo.java
@@ -18,27 +18,37 @@ package org.greenrobot.eventbus.meta;
 import org.greenrobot.eventbus.ThreadMode;
 
 public class SubscriberMethodInfo {
-    final String methodName;
+    final SubscriberMethodInvoker invoker;
+    final String methodString;
+    final Class<?> declaringClass;
     final ThreadMode threadMode;
     final Class<?> eventType;
     final int priority;
     final boolean sticky;
 
-    public SubscriberMethodInfo(String methodName, Class<?> eventType, ThreadMode threadMode,
+    public SubscriberMethodInfo(SubscriberMethodInvoker invoker,
+                                String methodString,
+                                Class<?> declaringClass,
+                                Class<?> eventType, ThreadMode threadMode,
                                 int priority, boolean sticky) {
-        this.methodName = methodName;
+        this.invoker = invoker;
+        this.methodString = methodString;
+        this.declaringClass = declaringClass;
         this.threadMode = threadMode;
         this.eventType = eventType;
         this.priority = priority;
         this.sticky = sticky;
     }
 
-    public SubscriberMethodInfo(String methodName, Class<?> eventType) {
-        this(methodName, eventType, ThreadMode.POSTING, 0, false);
+    public SubscriberMethodInfo(SubscriberMethodInvoker invoker,
+                                String methodString,
+                                Class<?> declaringClass,
+                                Class<?> eventType) {
+        this(invoker, methodString, declaringClass, eventType, ThreadMode.POSTING, 0, false);
     }
 
-    public SubscriberMethodInfo(String methodName, Class<?> eventType, ThreadMode threadMode) {
-        this(methodName, eventType, threadMode, 0, false);
+    public SubscriberMethodInfo(SubscriberMethodInvoker invoker, String methodString, Class<?> declaringClass, Class<?> eventType, ThreadMode threadMode) {
+        this(invoker, methodString, declaringClass, eventType, threadMode, 0, false);
     }
 
 }

--- a/EventBus/src/org/greenrobot/eventbus/meta/SubscriberMethodInvoker.java
+++ b/EventBus/src/org/greenrobot/eventbus/meta/SubscriberMethodInvoker.java
@@ -1,7 +1,9 @@
 package org.greenrobot.eventbus.meta;
 
 
-
+/**
+ * Interface for generated method invocation to avoid using reflection
+ */
 public interface SubscriberMethodInvoker {
     void invoke(Object subscriber, Object event);
 }

--- a/EventBus/src/org/greenrobot/eventbus/meta/SubscriberMethodInvoker.java
+++ b/EventBus/src/org/greenrobot/eventbus/meta/SubscriberMethodInvoker.java
@@ -1,0 +1,7 @@
+package org.greenrobot.eventbus.meta;
+
+
+
+public interface SubscriberMethodInvoker {
+    void invoke(Object subscriber, Object event);
+}

--- a/EventBusAnnotationProcessor/src/org/greenrobot/eventbus/annotationprocessor/EventBusAnnotationProcessor.java
+++ b/EventBusAnnotationProcessor/src/org/greenrobot/eventbus/annotationprocessor/EventBusAnnotationProcessor.java
@@ -76,7 +76,6 @@ public class EventBusAnnotationProcessor extends AbstractProcessor {
                         " passed to annotation processor");
                 return false;
             }
-            System.out.println("Yasir here :" + index);
             verbose = Boolean.parseBoolean(processingEnv.getOptions().get(OPTION_VERBOSE));
             int lastPeriod = index.lastIndexOf('.');
             String indexPackage = lastPeriod != -1 ? index.substring(0, lastPeriod) : null;
@@ -284,8 +283,12 @@ public class EventBusAnnotationProcessor extends AbstractProcessor {
 
             Subscribe subscribe = method.getAnnotation(Subscribe.class);
             List<String> parts = new ArrayList<>();
-            String invoker = "new SubscriberMethodInvoker(){public void invoke(Object subscriber, Object event){(("+subscriberClass+")subscriber)." + methodName + "(("+ eventClassString+ ")event);}}";
-            parts.add(callPrefix + "(" + invoker + ", \"" + methodName + "\", ");
+            writeLine(writer, 4, callPrefix , "(new SubscriberMethodInvoker() {");
+            writeLine(writer, 5,"public void invoke(Object subscriber, Object event) {");
+            writeLine(writer, 6,"((" + subscriberClass + ")subscriber)." + methodName + "((" + eventClassString + ")event);");
+            writeLine(writer, 5, "}");
+
+            parts.add("}, \"" + methodName + "\", ");
             String lineEnd = "),";
             if (subscribe.priority() == 0 && !subscribe.sticky()) {
                 if (subscribe.threadMode() == ThreadMode.POSTING) {
@@ -300,7 +303,7 @@ public class EventBusAnnotationProcessor extends AbstractProcessor {
                 parts.add(subscribe.priority() + ",");
                 parts.add(subscribe.sticky() + lineEnd);
             }
-            writeLine(writer, 3, parts.toArray(new String[parts.size()]));
+            writeLine(writer, 4, parts.toArray(new String[parts.size()]));
 
             if (verbose) {
                 processingEnv.getMessager().printMessage(Diagnostic.Kind.NOTE, "Indexed @Subscribe at " +

--- a/EventBusAnnotationProcessor/src/org/greenrobot/eventbus/annotationprocessor/EventBusAnnotationProcessor.java
+++ b/EventBusAnnotationProcessor/src/org/greenrobot/eventbus/annotationprocessor/EventBusAnnotationProcessor.java
@@ -68,6 +68,7 @@ public class EventBusAnnotationProcessor extends AbstractProcessor {
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment env) {
         Messager messager = processingEnv.getMessager();
+
         try {
             String index = processingEnv.getOptions().get(OPTION_EVENT_BUS_INDEX);
             if (index == null) {
@@ -75,6 +76,7 @@ public class EventBusAnnotationProcessor extends AbstractProcessor {
                         " passed to annotation processor");
                 return false;
             }
+            System.out.println("Yasir here :" + index);
             verbose = Boolean.parseBoolean(processingEnv.getOptions().get(OPTION_VERBOSE));
             int lastPeriod = index.lastIndexOf('.');
             String indexPackage = lastPeriod != -1 ? index.substring(0, lastPeriod) : null;
@@ -270,18 +272,20 @@ public class EventBusAnnotationProcessor extends AbstractProcessor {
         return (PackageElement) candidate;
     }
 
-    private void writeCreateSubscriberMethods(BufferedWriter writer, List<ExecutableElement> methods,
+    private void writeCreateSubscriberMethods(BufferedWriter writer, String subscriberClass, List<ExecutableElement> methods,
                                               String callPrefix, String myPackage) throws IOException {
         for (ExecutableElement method : methods) {
             List<? extends VariableElement> parameters = method.getParameters();
             TypeMirror paramType = getParamTypeMirror(parameters.get(0), null);
             TypeElement paramElement = (TypeElement) processingEnv.getTypeUtils().asElement(paramType);
             String methodName = method.getSimpleName().toString();
-            String eventClass = getClassString(paramElement, myPackage) + ".class";
+            String eventClassString = getClassString(paramElement, myPackage);
+            String eventClass = eventClassString + ".class";
 
             Subscribe subscribe = method.getAnnotation(Subscribe.class);
             List<String> parts = new ArrayList<>();
-            parts.add(callPrefix + "(\"" + methodName + "\",");
+            String invoker = "new SubscriberMethodInvoker(){public void invoke(Object subscriber, Object event){(("+subscriberClass+")subscriber)." + methodName + "(("+ eventClassString+ ")event);}}";
+            parts.add(callPrefix + "(" + invoker + ", \"" + methodName + "\", " + subscriberClass + ".class, ");
             String lineEnd = "),";
             if (subscribe.priority() == 0 && !subscribe.sticky()) {
                 if (subscribe.threadMode() == ThreadMode.POSTING) {
@@ -318,8 +322,10 @@ public class EventBusAnnotationProcessor extends AbstractProcessor {
             if (myPackage != null) {
                 writer.write("package " + myPackage + ";\n\n");
             }
+
             writer.write("import org.greenrobot.eventbus.meta.SimpleSubscriberInfo;\n");
             writer.write("import org.greenrobot.eventbus.meta.SubscriberMethodInfo;\n");
+            writer.write("import org.greenrobot.eventbus.meta.SubscriberMethodInvoker;\n");
             writer.write("import org.greenrobot.eventbus.meta.SubscriberInfo;\n");
             writer.write("import org.greenrobot.eventbus.meta.SubscriberInfoIndex;\n\n");
             writer.write("import org.greenrobot.eventbus.ThreadMode;\n\n");
@@ -370,7 +376,7 @@ public class EventBusAnnotationProcessor extends AbstractProcessor {
                         "putIndex(new SimpleSubscriberInfo(" + subscriberClass + ".class,",
                         "true,", "new SubscriberMethodInfo[] {");
                 List<ExecutableElement> methods = methodsByClass.get(subscriberTypeElement);
-                writeCreateSubscriberMethods(writer, methods, "new SubscriberMethodInfo", myPackage);
+                writeCreateSubscriberMethods(writer, subscriberClass, methods, "new SubscriberMethodInfo", myPackage);
                 writer.write("        }));\n\n");
             } else {
                 writer.write("        // Subscriber not visible to index: " + subscriberClass + "\n");

--- a/EventBusAnnotationProcessor/src/org/greenrobot/eventbus/annotationprocessor/EventBusAnnotationProcessor.java
+++ b/EventBusAnnotationProcessor/src/org/greenrobot/eventbus/annotationprocessor/EventBusAnnotationProcessor.java
@@ -285,7 +285,7 @@ public class EventBusAnnotationProcessor extends AbstractProcessor {
             Subscribe subscribe = method.getAnnotation(Subscribe.class);
             List<String> parts = new ArrayList<>();
             String invoker = "new SubscriberMethodInvoker(){public void invoke(Object subscriber, Object event){(("+subscriberClass+")subscriber)." + methodName + "(("+ eventClassString+ ")event);}}";
-            parts.add(callPrefix + "(" + invoker + ", \"" + methodName + "\", " + subscriberClass + ".class, ");
+            parts.add(callPrefix + "(" + invoker + ", \"" + methodName + "\", ");
             String lineEnd = "),";
             if (subscribe.priority() == 0 && !subscribe.sticky()) {
                 if (subscribe.threadMode() == ThreadMode.POSTING) {

--- a/EventBusTest/src/org/greenrobot/eventbus/EventBusIndexTest.java
+++ b/EventBusTest/src/org/greenrobot/eventbus/EventBusIndexTest.java
@@ -41,7 +41,7 @@ public class EventBusIndexTest {
                             public void invoke(Object subscriber, Object event) {
                                 ((EventBusIndexTest)subscriber).someMethodWithoutAnnotation((String)event);
                             }
-                        }, "someMethodWithoutAnnotation", EventBusIndexTest.class, String.class)
+                        }, "someMethodWithoutAnnotation", String.class)
                 };
                 return new SimpleSubscriberInfo(EventBusIndexTest.class, false, methodInfos);
             }

--- a/EventBusTest/src/org/greenrobot/eventbus/EventBusIndexTest.java
+++ b/EventBusTest/src/org/greenrobot/eventbus/EventBusIndexTest.java
@@ -20,6 +20,7 @@ import org.greenrobot.eventbus.meta.SimpleSubscriberInfo;
 import org.greenrobot.eventbus.meta.SubscriberInfo;
 import org.greenrobot.eventbus.meta.SubscriberInfoIndex;
 import org.greenrobot.eventbus.meta.SubscriberMethodInfo;
+import org.greenrobot.eventbus.meta.SubscriberMethodInvoker;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -35,7 +36,12 @@ public class EventBusIndexTest {
             public SubscriberInfo getSubscriberInfo(Class<?> subscriberClass) {
                 Assert.assertEquals(EventBusIndexTest.class, subscriberClass);
                 SubscriberMethodInfo[] methodInfos = {
-                        new SubscriberMethodInfo("someMethodWithoutAnnotation", String.class)
+                        new SubscriberMethodInfo(new SubscriberMethodInvoker() {
+                            @Override
+                            public void invoke(Object subscriber, Object event) {
+                                ((EventBusIndexTest)subscriber).someMethodWithoutAnnotation((String)event);
+                            }
+                        }, "someMethodWithoutAnnotation", EventBusIndexTest.class, String.class)
                 };
                 return new SimpleSubscriberInfo(EventBusIndexTest.class, false, methodInfos);
             }


### PR DESCRIPTION
While generating the Subscriber indices there is an opportunity to do away with reflection. 

Using the interface SubscriberMethodInvoker anonymous classes are generated which access the public methods of the class directly.

Older implementation : 

![image](https://cloud.githubusercontent.com/assets/13655724/22378392/7c19fb2a-e4db-11e6-9a2c-2502e5a715d9.png)


New Implementation : 

![image](https://cloud.githubusercontent.com/assets/13655724/22378459/b07b70a6-e4db-11e6-84c4-fa2ba7c470a5.png)
