### PR TITLE
Specify SubscriberIndex size when initializing HashMap

### DIFF
--- a/EventBusAnnotationProcessor/src/org/greenrobot/eventbus/annotationprocessor/EventBusAnnotationProcessor.java
+++ b/EventBusAnnotationProcessor/src/org/greenrobot/eventbus/annotationprocessor/EventBusAnnotationProcessor.java
@@ -318,6 +318,14 @@ public class EventBusAnnotationProcessor extends AbstractProcessor {
             if (myPackage != null) {
                 writer.write("package " + myPackage + ";\n\n");
             }
+
+            int indexSize = methodsByClass.size() - classesToSkip.size();
+
+            // sanity check
+             if (indexSize < 0) {
+                indexSize = 0;
+            }
+
             writer.write("import org.greenrobot.eventbus.meta.SimpleSubscriberInfo;\n");
             writer.write("import org.greenrobot.eventbus.meta.SubscriberMethodInfo;\n");
             writer.write("import org.greenrobot.eventbus.meta.SubscriberInfo;\n");
@@ -329,7 +337,7 @@ public class EventBusAnnotationProcessor extends AbstractProcessor {
             writer.write("public class " + clazz + " implements SubscriberInfoIndex {\n");
             writer.write("    private static final Map<Class<?>, SubscriberInfo> SUBSCRIBER_INDEX;\n\n");
             writer.write("    static {\n");
-            writer.write("        SUBSCRIBER_INDEX = new HashMap<Class<?>, SubscriberInfo>();\n\n");
+            writer.write("        SUBSCRIBER_INDEX = new HashMap<Class<?>, SubscriberInfo>(" + indexSize + ");\n\n");
             writeIndexLines(writer, myPackage);
             writer.write("    }\n\n");
             writer.write("    private static void putIndex(SubscriberInfo info) {\n");


### PR DESCRIPTION
Initializing the HashMap with a specific size is an optimization for when we're adding a large number of subscribers to the index. By default the HashMap will only be created with a capacity of 4, so if we add a large number of subscribers the map will have to expand it's size several times. This can cause garbage collections that slow down App launch.