### PR TITLE
Fix empty test suite error for EventBusTest module.

### DIFF
--- a/EventBusTest/AndroidManifest.xml
+++ b/EventBusTest/AndroidManifest.xml
@@ -6,15 +6,11 @@
 
     <uses-sdk android:minSdkVersion="8" />
 
-    <instrumentation
-        android:name="android.test.InstrumentationTestRunner"
-        android:targetPackage="de.greenrobot.event.test" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
     <application
         android:allowBackup="false"
         android:label="EventBus Test" >
-        <uses-library android:name="android.test.runner" />
     </application>
 
 </manifest>


### PR DESCRIPTION
- Closes https://github.com/greenrobot/EventBus/issues/439
- Remove outdated instrumentation tags from AndroidManifest.xml to stop overriding build.gradle config. Make sure to remove existing run configurations, sync your project, then right click class/method to run test.

-ut