### PR TITLE
Update EventBus.java

### DIFF
--- a/EventBus/src/org/greenrobot/eventbus/EventBus.java
+++ b/EventBus/src/org/greenrobot/eventbus/EventBus.java
@@ -358,7 +358,16 @@ public class EventBus {
     }
 
     public boolean hasSubscriberForEvent(Class<?> eventClass) {
-        List<Class<?>> eventTypes = lookupAllEventTypes(eventClass);
+       
+        List<Class<?>> eventTypes ;
+        
+        if(eventInheritance){
+            eventTypes = lookupAllEventTypes(eventClass);
+        }else{
+            eventTypes = new ArrayList<>();
+            eventTypes.add(eventClass);
+        }    
+        
         if (eventTypes != null) {
             int countTypes = eventTypes.size();
             for (int h = 0; h < countTypes; h++) {


### PR DESCRIPTION
There is no method to handle this child event, but there is a method to handle the parent event of this event, the method hasSubscriberForEvent returns true. However, when the variable hasSubscriberForEvent is false, the handler for the parent event is not called to handle the event, causing the event not to be processed.