### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Add EventBus to your project
 
 Via Gradle:
 ```gradle
-compile 'org.greenrobot:eventbus:3.1.1'
+implementation 'org.greenrobot:eventbus:3.1.1'
 ```
 
 Via Maven:


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.