### PR TITLE
make PackageElement detect in the official recommend way

### DIFF
--- a/EventBusAnnotationProcessor/src/org/greenrobot/eventbus/annotationprocessor/EventBusAnnotationProcessor.java
+++ b/EventBusAnnotationProcessor/src/org/greenrobot/eventbus/annotationprocessor/EventBusAnnotationProcessor.java
@@ -37,6 +37,7 @@ import javax.lang.model.element.Modifier;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
@@ -264,7 +265,7 @@ public class EventBusAnnotationProcessor extends AbstractProcessor {
 
     private PackageElement getPackageElement(TypeElement subscriberClass) {
         Element candidate = subscriberClass.getEnclosingElement();
-        while (!(candidate instanceof PackageElement)) {
+        while (candidate.getKind() != ElementKind.PACKAGE) {
             candidate = candidate.getEnclosingElement();
         }
         return (PackageElement) candidate;


### PR DESCRIPTION
According to the official Java document, I think we should use **Element.getKind()** instead of **instanceof** to detect whether an Element is PackageElement or not.

Quote:
https://docs.oracle.com/javase/7/docs/api/javax/lang/model/element/Element.html
