### PR TITLE
Fix for crash on AndroidX

### DIFF
--- a/EventBus/src/org/greenrobot/eventbus/SubscriberMethodFinder.java
+++ b/EventBus/src/org/greenrobot/eventbus/SubscriberMethodFinder.java
@@ -160,21 +160,21 @@ class SubscriberMethodFinder {
         for (Method method : methods) {
             int modifiers = method.getModifiers();
             if ((modifiers & Modifier.PUBLIC) != 0 && (modifiers & MODIFIERS_IGNORE) == 0) {
-                Class<?>[] parameterTypes = method.getParameterTypes();
-                if (parameterTypes.length == 1) {
-                    Subscribe subscribeAnnotation = method.getAnnotation(Subscribe.class);
-                    if (subscribeAnnotation != null) {
+                Subscribe subscribeAnnotation = method.getAnnotation(Subscribe.class);
+                if (subscribeAnnotation != null) {
+                    Class<?>[] parameterTypes = method.getParameterTypes();
+                    if (parameterTypes.length == 1) {
                         Class<?> eventType = parameterTypes[0];
                         if (findState.checkAdd(method, eventType)) {
                             ThreadMode threadMode = subscribeAnnotation.threadMode();
                             findState.subscriberMethods.add(new SubscriberMethod(method, eventType, threadMode,
                                     subscribeAnnotation.priority(), subscribeAnnotation.sticky()));
                         }
+                    } else if (strictMethodVerification) {
+                        String methodName = method.getDeclaringClass().getName() + "." + method.getName();
+                        throw new EventBusException("@Subscribe method " + methodName +
+                                "must have exactly 1 parameter but has " + parameterTypes.length);
                     }
-                } else if (strictMethodVerification && method.isAnnotationPresent(Subscribe.class)) {
-                    String methodName = method.getDeclaringClass().getName() + "." + method.getName();
-                    throw new EventBusException("@Subscribe method " + methodName +
-                            "must have exactly 1 parameter but has " + parameterTypes.length);
                 }
             } else if (strictMethodVerification && method.isAnnotationPresent(Subscribe.class)) {
                 String methodName = method.getDeclaringClass().getName() + "." + method.getName();
@@ -258,14 +258,15 @@ class SubscriberMethodFinder {
                 clazz = null;
             } else {
                 clazz = clazz.getSuperclass();
-                String clazzName = clazz.getName();
-                /** Skip system classes, this just degrades performance. */
-                if (clazzName.startsWith("java.") || clazzName.startsWith("javax.") || clazzName.startsWith("android.")
-                        || clazzName.startsWith("androidx.")) {
-                    clazz = null;
+                if (clazz != null) {
+                    String clazzName = clazz.getName();
+                    // Skip system classes, this just degrades performance.
+                    if (clazzName.startsWith("java.") || clazzName.startsWith("javax.")
+                            || clazzName.startsWith("android.") || clazzName.startsWith("androidx.")) {
+                        clazz = null;
+                    }
                 }
             }
         }
     }
-
 }


### PR DESCRIPTION
Eventbus is crashing when my app is running on a device with an API level below 26 and using the AndroidX libraries.

The problem is that a NoClassDefFoundError is being thrown for the TextClassifier that's a parameter in the AppCompatTextView#setTextClassifier() method. The reflection code you use doesn't filter for API level, unfortunately.

A quick fix is to add "androidx." to the system classes in the moveToSuperClass() method. You should probably do this for performance reasons in any case.