### PR TITLE
EventBus class add setDefault method

### DIFF
--- a/EventBus/src/org/greenrobot/eventbus/EventBus.java
+++ b/EventBus/src/org/greenrobot/eventbus/EventBus.java
@@ -90,6 +90,10 @@ public class EventBus {
         return instance;
     }
 
+    public static void setDefault(EventBus instance) {
+        EventBus.defaultInstance = instance;
+    }
+
     public static EventBusBuilder builder() {
         return new EventBusBuilder();
     }


### PR DESCRIPTION
Hello, I use the EventBus Apt plug-ins, but involve changes to the code is very much, very easy to appear omissions, I myself have done many frameworks, I object to this kind of practice, because I can't make good use of it, it does not conform to the open closed principle Java design patterns, I recommend to extend EventBus method, because in many cases, we only need a singleton EventBus instance, to the EventBus class maintenance, inherit the EventBus items and replace the original code cost is very high,I recommend solving this problem this way, thank you