### PR TITLE
Adaptive Android X

### DIFF
--- a/EventBus/src/org/greenrobot/eventbus/SubscriberMethodFinder.java
+++ b/EventBus/src/org/greenrobot/eventbus/SubscriberMethodFinder.java
@@ -260,7 +260,8 @@ class SubscriberMethodFinder {
                 clazz = clazz.getSuperclass();
                 String clazzName = clazz.getName();
                 /** Skip system classes, this just degrades performance. */
-                if (clazzName.startsWith("java.") || clazzName.startsWith("javax.") || clazzName.startsWith("android.")) {
+                if (clazzName.startsWith("java.") || clazzName.startsWith("javax.")
+                        || clazzName.startsWith("android.") || clazzName.startsWith("androidx.")) {
                     clazz = null;
                 }
             }


### PR DESCRIPTION
Google no longer maintains the Support library and I think we should skip the classes under the AndroidX package

`android.support.v7.app.AppCompatActivity  --->  androidx.appcompat.app.AppCompatActivity`
`android.support.v4.app.Fragment   --->   androidx.fragment.app.Fragment`