### PR TITLE
Support event setting filter

### DIFF
--- a/EventBus/src/org/greenrobot/eventbus/Filter.java
+++ b/EventBus/src/org/greenrobot/eventbus/Filter.java
@@ -1,0 +1,14 @@
+package org.greenrobot.eventbus;
+
+/**
+ * Filter those subscription events to pass
+ *
+ * @author miqt:https://github.com/miqt
+ */
+public interface Filter {
+    /**
+     * @param subscription
+     * @return true is can invoke Subscriber false are not
+     */
+    public boolean allow(Subscription subscription);
+}

--- a/EventBus/src/org/greenrobot/eventbus/Subscription.java
+++ b/EventBus/src/org/greenrobot/eventbus/Subscription.java
@@ -15,7 +15,7 @@
  */
 package org.greenrobot.eventbus;
 
-final class Subscription {
+public final class Subscription {
     final Object subscriber;
     final SubscriberMethod subscriberMethod;
     /**
@@ -23,6 +23,14 @@ final class Subscription {
      * {@link EventBus#invokeSubscriber(PendingPost)} to prevent race conditions.
      */
     volatile boolean active;
+
+    public Object getSubscriber() {
+        return subscriber;
+    }
+
+    public SubscriberMethod getSubscriberMethod() {
+        return subscriberMethod;
+    }
 
     Subscription(Object subscriber, SubscriberMethod subscriberMethod) {
         this.subscriber = subscriber;

--- a/EventBusTestJava/src/main/java/org/greenrobot/eventbus/EventBusFilterTest.java
+++ b/EventBusTestJava/src/main/java/org/greenrobot/eventbus/EventBusFilterTest.java
@@ -3,32 +3,34 @@ package org.greenrobot.eventbus;
 import org.junit.Test;
 
 /**
- * Created by t54 on 2019/4/28.
+ * @author miqt
  */
 
 public class EventBusFilterTest extends AbstractEventBusTest {
     @Test
-    public void test() {
+    public void testFilter() {
         eventBus.register(this);
+
         eventBus.post("hello", filter);
         eventBus.post("no filter hello");
 
         eventBus.postSticky("hello Sticky", filter);
         eventBus.postSticky("no filter hello Sticky");
+
         eventBus.unregister(this);
     }
 
     @Subscribe
-    public void goodDay(String hello) {
-        System.out.println(EventBus.TAG + ":goodDay:" + hello);
+    public void goodDay(String str) {
+        System.out.println(EventBus.TAG + ":goodDay:" + str);
     }
 
     @Subscribe
-    public void badDay(String hello) {
-        System.out.println(EventBus.TAG + ":badDay:" + hello);
+    public void badDay(String str) {
+        System.out.println(EventBus.TAG + ":badDay:" + str);
     }
 
-    Filter filter = new Filter() {
+    private Filter filter = new Filter() {
         @Override
         public boolean allow(Subscription subscription) {
             return subscription.getSubscriberMethod().method.getName().equals("goodDay");

--- a/EventBusTestJava/src/main/java/org/greenrobot/eventbus/EventBusFilterTest.java
+++ b/EventBusTestJava/src/main/java/org/greenrobot/eventbus/EventBusFilterTest.java
@@ -1,0 +1,37 @@
+package org.greenrobot.eventbus;
+
+import org.junit.Test;
+
+/**
+ * Created by t54 on 2019/4/28.
+ */
+
+public class EventBusFilterTest extends AbstractEventBusTest {
+    @Test
+    public void test() {
+        eventBus.register(this);
+        eventBus.post("hello", filter);
+        eventBus.post("no filter hello");
+
+        eventBus.postSticky("hello Sticky", filter);
+        eventBus.postSticky("no filter hello Sticky");
+        eventBus.unregister(this);
+    }
+
+    @Subscribe
+    public void goodDay(String hello) {
+        System.out.println(EventBus.TAG + ":goodDay:" + hello);
+    }
+
+    @Subscribe
+    public void badDay(String hello) {
+        System.out.println(EventBus.TAG + ":badDay:" + hello);
+    }
+
+    Filter filter = new Filter() {
+        @Override
+        public boolean allow(Subscription subscription) {
+            return subscription.getSubscriberMethod().method.getName().equals("goodDay");
+        }
+    };
+}


### PR DESCRIPTION
Sometimes I just want to send a Bean out to let other members update ui or do other things.
But because of the characteristics of Eventbus, I have to define many types to wrap my data, which is very troublesome.
So I want to be able to set filters to ensure that those methods are not going to arrive.

I added a Filter parameter to the post method:
```java
public interface Filter {
    /**
     * @param subscription
     * @return true is can invoke Subscriber false are not
     */
    public boolean allow(Subscription subscription);
}
```
This is the test code: [EventBusFilterTest.java](https://github.com/miqt/EventBus/blob/support-event-filter/EventBusTestJava/src/main/java/org/greenrobot/eventbus/EventBusFilterTest.java)
