### PR TITLE
Update publishing setup

### DIFF
--- a/EventBus/build.gradle
+++ b/EventBus/build.gradle
@@ -1,27 +1,19 @@
 apply plugin: 'java'
-apply plugin: 'idea'
 
 archivesBaseName = 'eventbus'
 group = 'org.greenrobot'
 version = '3.1.1'
 sourceCompatibility = 1.7
 
-// Still unsupported, see http://issues.gradle.org/browse/GRADLE-784
-// Like this, it won't appear at all in the POM
-configurations {
-    provided
-}
-
 dependencies {
-    provided 'com.google.android:android:4.1.1.4'
-    provided 'com.google.android:android-test:4.1.1.4'
-    provided 'com.google.android:annotations:4.1.1.4'
-    provided 'com.google.android:support-v4:r7'
+    compileOnly 'com.google.android:android:4.1.1.4'
+    compileOnly 'com.google.android:android-test:4.1.1.4'
+    compileOnly 'com.google.android:annotations:4.1.1.4'
+    compileOnly 'com.google.android:support-v4:r7'
 }
 
 sourceSets {
     main {
-        compileClasspath += configurations.provided
         java {
             srcDir 'src'
             // exclude 'de/greenrobot/event/util/**'
@@ -29,17 +21,10 @@ sourceSets {
     }
 }
 
-idea {
-    module {
-        scopes.PROVIDED.plus += [configurations.provided]
-    }
-}
-
 apply from: rootProject.file("gradle/publish.gradle")
 
 javadoc {
     failOnError = false
-    classpath += configurations.provided
     title = "EventBus ${version} API"
 	options.bottom = 'Available under the Apache License, Version 2.0 - <i>Copyright &#169; 2012-2017 <a href="http://greenrobot.org">greenrobot.org</a>. All Rights Reserved.</i>'
 }

--- a/EventBus/build.gradle
+++ b/EventBus/build.gradle
@@ -1,6 +1,4 @@
 apply plugin: 'java'
-apply plugin: 'maven'
-apply plugin: 'signing'
 apply plugin: 'idea'
 
 archivesBaseName = 'eventbus'
@@ -8,19 +6,10 @@ group = 'org.greenrobot'
 version = '3.1.1'
 sourceCompatibility = 1.7
 
-def isSnapshot = version.endsWith('-SNAPSHOT')
-def sonatypeRepositoryUrl
-if(isSnapshot) {
-	sonatypeRepositoryUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
-} else {
-	sonatypeRepositoryUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-}
-
 // Still unsupported, see http://issues.gradle.org/browse/GRADLE-784
 // Like this, it won't appear at all in the POM
 configurations {
     provided
-    deployerJars
 }
 
 dependencies {
@@ -28,8 +17,6 @@ dependencies {
     provided 'com.google.android:android-test:4.1.1.4'
     provided 'com.google.android:annotations:4.1.1.4'
     provided 'com.google.android:support-v4:r7'
-    // deployerJars 'org.apache.maven.wagon:wagon-webdav-jackrabbit:2.4'
-    deployerJars 'org.apache.maven.wagon:wagon-webdav:1.0-beta-2'
 }
 
 sourceSets {
@@ -47,6 +34,8 @@ idea {
         scopes.PROVIDED.plus += [configurations.provided]
     }
 }
+
+apply from: rootProject.file("gradle/publish.gradle")
 
 javadoc {
     failOnError = false
@@ -71,72 +60,14 @@ artifacts {
     archives sourcesJar
 }
 
-signing {
-    if(project.hasProperty('signing.keyId') && project.hasProperty('signing.password') &&
-    project.hasProperty('signing.secretKeyRingFile')) {
-        sign configurations.archives
-    } else {
-        println "Signing information missing/incomplete for ${project.name}"
-    }
-}
-
 uploadArchives {
     repositories {
         mavenDeployer {
-            if (project.hasProperty('preferedRepo')) println "preferedRepo = $preferedRepo"
-            if (project.hasProperty('preferedRepo') && preferedRepo == 'local') {
-                println "Deploying to local repo (aka install)..."
-                repository url: repositories.mavenLocal().url
-            } else if(project.hasProperty('preferedRepo') && project.hasProperty('preferedUsername')
-                && project.hasProperty('preferedPassword')) {
-                configuration = configurations.deployerJars
-                repository(url: preferedRepo) {
-                    authentication(userName: preferedUsername, password: preferedPassword)
-                }
-            } else if(project.hasProperty('sonatypeUsername') && project.hasProperty('sonatypePassword')) {
-                beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-                repository(url: sonatypeRepositoryUrl) {
-                    authentication(userName: sonatypeUsername, password: sonatypePassword)
-                }
-            } else {
-                println "Settings sonatypeUsername/sonatypePassword missing/incomplete for ${project.name}"
-            }
+            // Common setup is defined in publish.gradle.
+
             pom.project {
                name 'EventBus'
-               packaging 'jar'
-               description 'EventBus is a publish/subscribe event bus optimized for Android .'
-               url 'http://greenrobot.org/eventbus/'
-
-               scm {
-                   url 'https://github.com/greenrobot/EventBus'
-                   connection 'scm:git@github.com:greenrobot/EventBus.git'
-                   developerConnection 'scm:git@github.com:greenrobot/EventBus.git'
-               }
-
-               licenses {
-                   license {
-                       name 'The Apache Software License, Version 2.0'
-                       url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                       distribution 'repo'
-                   }
-               }
-
-               developers {
-                   developer {
-                       id 'greenrobot'
-                       name 'greenrobot'
-                   }
-               }
-               
-               issueManagement {
-                   system 'GitHub Issues'
-                   url 'https://github.com/greenrobot/EventBus/issues'
-               }
-
-               organization {
-                   name 'greenrobot'
-                   url 'http://greenrobot.org'
-               }
+               description 'EventBus is a publish/subscribe event bus optimized for Android.'
            }
         }
     }

--- a/EventBusAnnotationProcessor/build.gradle
+++ b/EventBusAnnotationProcessor/build.gradle
@@ -1,6 +1,4 @@
 apply plugin: 'java'
-apply plugin: 'maven'
-apply plugin: 'signing'
 
 archivesBaseName = 'eventbus-annotation-processor'
 group = 'org.greenrobot'
@@ -8,25 +6,15 @@ version = '3.1.0'
 
 sourceCompatibility = 1.7
 
-def isSnapshot = version.endsWith('-SNAPSHOT')
-def sonatypeRepositoryUrl
-if (isSnapshot) {
-    sonatypeRepositoryUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
-} else {
-    sonatypeRepositoryUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-}
-
 // Still unsupported, see http://issues.gradle.org/browse/GRADLE-784
 // Like this, it won't appear at all in the POM
 configurations {
     provided
-    deployerJars
 }
 
 dependencies {
     compile project(':eventbus')
     compile 'de.greenrobot:java-common:2.3.1'
-    deployerJars 'org.apache.maven.wagon:wagon-webdav:1.0-beta-2'
 }
 
 sourceSets {
@@ -40,6 +28,8 @@ sourceSets {
         }
     }
 }
+
+apply from: rootProject.file("gradle/publish.gradle")
 
 javadoc {
     classpath += configurations.provided
@@ -63,73 +53,14 @@ artifacts {
     archives sourcesJar
 }
 
-signing {
-    if (project.hasProperty('signing.keyId') && project.hasProperty('signing.password') &&
-            project.hasProperty('signing.secretKeyRingFile')) {
-        sign configurations.archives
-    } else {
-        println "Signing information missing/incomplete for ${project.name}"
-    }
-}
-
 uploadArchives {
     repositories {
         mavenDeployer {
-            if (project.hasProperty('preferedRepo')) println "preferedRepo = $preferedRepo"
-            if (project.hasProperty('preferedRepo') && preferedRepo == 'local') {
-                println "Deploying to local repo (aka install)..."
-                repository url: repositories.mavenLocal().url
-            } else if (project.hasProperty('preferedRepo') && project.hasProperty('preferedUsername')
-                    && project.hasProperty('preferedPassword')) {
-                configuration = configurations.deployerJars
-                repository(url: preferedRepo) {
-                    authentication(userName: preferedUsername, password: preferedPassword)
-                }
-            } else if (project.hasProperty('sonatypeUsername') && project.hasProperty('sonatypePassword')) {
-                beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-                repository(url: sonatypeRepositoryUrl) {
-                    authentication(userName: sonatypeUsername, password: sonatypePassword)
-                }
-            } else {
-                println "Settings sonatypeUsername/sonatypePassword missing/incomplete for ${project.name}"
-            }
+            // Common setup is defined in publish.gradle.
 
             pom.project {
                 name 'EventBus Annotation Processor'
-                packaging 'jar'
                 description 'Precompiler for EventBus Annotations.'
-                url 'http://greenrobot.org/eventbus/'
-
-                scm {
-                    url 'https://github.com/greenrobot/EventBus'
-                    connection 'scm:git@github.com:greenrobot/EventBus.git'
-                    developerConnection 'scm:git@github.com:greenrobot/EventBus.git'
-                }
-
-                licenses {
-                    license {
-                        name 'The Apache Software License, Version 2.0'
-                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                        distribution 'repo'
-                    }
-                }
-
-                developers {
-                    developer {
-                        id 'greenrobot'
-                        name 'greenrobot'
-                    }
-                }
-
-                issueManagement {
-                    system 'GitHub Issues'
-                    url 'https://github.com/greenrobot/EventBus/issues'
-                }
-
-                organization {
-                    name 'greenrobot'
-                    url 'http://greenrobot.org'
-                }
             }
         }
     }

--- a/EventBusAnnotationProcessor/build.gradle
+++ b/EventBusAnnotationProcessor/build.gradle
@@ -6,20 +6,13 @@ version = '3.1.0'
 
 sourceCompatibility = 1.7
 
-// Still unsupported, see http://issues.gradle.org/browse/GRADLE-784
-// Like this, it won't appear at all in the POM
-configurations {
-    provided
-}
-
 dependencies {
-    compile project(':eventbus')
-    compile 'de.greenrobot:java-common:2.3.1'
+    implementation project(':eventbus')
+    implementation 'de.greenrobot:java-common:2.3.1'
 }
 
 sourceSets {
     main {
-        compileClasspath += configurations.provided
         java {
             srcDir 'src'
         }
@@ -32,7 +25,6 @@ sourceSets {
 apply from: rootProject.file("gradle/publish.gradle")
 
 javadoc {
-    classpath += configurations.provided
     title = "EventBus Annotation Processor ${version} API"
 	options.bottom = 'Available under the Apache License, Version 2.0 - <i>Copyright &#169; 2015-2016 <a href="http://greenrobot.org">greenrobot.org</a>. All Rights Reserved.</i>'
 }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,0 +1,95 @@
+// Configures common publishing settings.
+
+apply plugin: "maven"
+apply plugin: "signing"
+
+configurations {
+    deployerJars
+}
+
+dependencies {
+    // Using an older version to remain compatible with Wagon API used by Gradle/Maven.
+    deployerJars 'org.apache.maven.wagon:wagon-webdav-jackrabbit:3.2.0'
+    deployerJars 'org.apache.maven.wagon:wagon-ftp:3.3.2'
+}
+
+signing {
+    if (project.hasProperty('signing.keyId') && project.hasProperty('signing.password') &&
+            project.hasProperty('signing.secretKeyRingFile')) {
+        sign configurations.archives
+    } else {
+        println "Signing information missing/incomplete for ${project.name}."
+    }
+}
+
+// Use afterEvaluate or dependencies might be lost in the generated POM.
+afterEvaluate { project ->
+    uploadArchives {
+        repositories {
+            mavenDeployer {
+                def preferredRepo = project.findProperty('preferredRepo')
+                println "preferredRepo=$preferredRepo"
+
+                if (preferredRepo == 'local') {
+                    repository url: repositories.mavenLocal().url
+                } else if (preferredRepo != null
+                        && project.hasProperty('preferredUsername')
+                        && project.hasProperty('preferredPassword')) {
+                    configuration = configurations.deployerJars
+                    repository(url: repositoryUrl) {
+                        authentication(userName: preferredUsername, password: preferredPassword)
+                    }
+                } else if (project.hasProperty('sonatypeUsername')
+                        && project.hasProperty('sonatypePassword')) {
+                    beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+                    def isSnapshot = version.endsWith('-SNAPSHOT')
+                    def sonatypeRepositoryUrl = isSnapshot
+                            ? "https://oss.sonatype.org/content/repositories/snapshots/"
+                            : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                    repository(url: sonatypeRepositoryUrl) {
+                        authentication(userName: sonatypeUsername, password: sonatypePassword)
+                    }
+                } else {
+                    println "Deployment settings missing/incomplete for ${project.name}."
+                }
+
+                // Common properties, projects still need to set name and description.
+                pom.project {
+                    packaging 'jar'
+                    url 'http://greenrobot.org/eventbus/'
+
+                    scm {
+                        url 'https://github.com/greenrobot/EventBus'
+                        connection 'scm:git@github.com:greenrobot/EventBus.git'
+                        developerConnection 'scm:git@github.com:greenrobot/EventBus.git'
+                    }
+
+                    licenses {
+                        license {
+                            name 'The Apache Software License, Version 2.0'
+                            url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                            distribution 'repo'
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            id 'greenrobot'
+                            name 'greenrobot'
+                        }
+                    }
+
+                    issueManagement {
+                        system 'GitHub Issues'
+                        url 'https://github.com/greenrobot/EventBus/issues'
+                    }
+
+                    organization {
+                        name 'greenrobot'
+                        url 'http://greenrobot.org'
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Use new dependency configurations. Note: for the processor this changes the dependencies on EventBus and java-common from `compile` to `runtime` in the resulting POM. Based on a quick test this is fine.

Change from `prefered` to `preferred` properties.

Extract common publishing script.