### PR TITLE
Ignore androidx package to avoid tripping over new API.

### DIFF
--- a/EventBus/src/org/greenrobot/eventbus/SubscriberMethodFinder.java
+++ b/EventBus/src/org/greenrobot/eventbus/SubscriberMethodFinder.java
@@ -259,8 +259,12 @@ class SubscriberMethodFinder {
             } else {
                 clazz = clazz.getSuperclass();
                 String clazzName = clazz.getName();
-                /** Skip system classes, this just degrades performance. */
-                if (clazzName.startsWith("java.") || clazzName.startsWith("javax.") || clazzName.startsWith("android.")) {
+                /* Skip system classes, improves performance and avoids java.lang.NoClassDefFoundError
+                 if e.g. AndroidX classes use new API. https://github.com/greenrobot/EventBus/issues/608 */
+                if (clazzName.startsWith("java.")
+                        || clazzName.startsWith("javax.")
+                        || clazzName.startsWith("android.")
+                        || clazzName.startsWith("androidx.")) {
                     clazz = null;
                 }
             }


### PR DESCRIPTION
This closes https://github.com/greenrobot/EventBus/issues/608.

AndroidX classes may use new API. `SubscriberMethodFinder.findUsingReflectionInSingleClass()` will trip over those (`java.lang.NoClassDefFoundError`) even if using an index as `SubscriberMethodFinder.findUsingInfo()` checks all super classes until `FindState.moveToSuperclass()` causes `FindState.clazz` to be `null` (is this a bug, e.g. should `FindState.skipSuperClasses` be `true` if using an index?).