### PR TITLE
add the ability of registerWeak, which could help reduce memory leak

### DIFF
--- a/EventBus/src/org/greenrobot/eventbus/AsyncPoster.java
+++ b/EventBus/src/org/greenrobot/eventbus/AsyncPoster.java
@@ -31,7 +31,7 @@ class AsyncPoster implements Runnable, Poster {
         queue = new PendingPostQueue();
     }
 
-    public void enqueue(Subscription subscription, Object event) {
+    public void enqueue(ISubscription subscription, Object event) {
         PendingPost pendingPost = PendingPost.obtainPendingPost(subscription, event);
         queue.enqueue(pendingPost);
         eventBus.getExecutorService().execute(this);

--- a/EventBus/src/org/greenrobot/eventbus/BackgroundPoster.java
+++ b/EventBus/src/org/greenrobot/eventbus/BackgroundPoster.java
@@ -34,7 +34,7 @@ final class BackgroundPoster implements Runnable, Poster {
         queue = new PendingPostQueue();
     }
 
-    public void enqueue(Subscription subscription, Object event) {
+    public void enqueue(ISubscription subscription, Object event) {
         PendingPost pendingPost = PendingPost.obtainPendingPost(subscription, event);
         synchronized (this) {
             queue.enqueue(pendingPost);

--- a/EventBus/src/org/greenrobot/eventbus/HandlerPoster.java
+++ b/EventBus/src/org/greenrobot/eventbus/HandlerPoster.java
@@ -34,7 +34,7 @@ public class HandlerPoster extends Handler implements Poster {
         queue = new PendingPostQueue();
     }
 
-    public void enqueue(Subscription subscription, Object event) {
+    public void enqueue(ISubscription subscription, Object event) {
         PendingPost pendingPost = PendingPost.obtainPendingPost(subscription, event);
         synchronized (this) {
             queue.enqueue(pendingPost);

--- a/EventBus/src/org/greenrobot/eventbus/ISubscription.java
+++ b/EventBus/src/org/greenrobot/eventbus/ISubscription.java
@@ -1,0 +1,12 @@
+package org.greenrobot.eventbus;
+
+public interface ISubscription {
+
+    public Object getSubscriber();
+
+    public SubscriberMethod getSubscriberMethod();
+
+    public boolean isActive();
+
+    public void setIsActive(boolean isActive);
+}

--- a/EventBus/src/org/greenrobot/eventbus/PendingPost.java
+++ b/EventBus/src/org/greenrobot/eventbus/PendingPost.java
@@ -22,15 +22,15 @@ final class PendingPost {
     private final static List<PendingPost> pendingPostPool = new ArrayList<PendingPost>();
 
     Object event;
-    Subscription subscription;
+    ISubscription subscription;
     PendingPost next;
 
-    private PendingPost(Object event, Subscription subscription) {
+    private PendingPost(Object event, ISubscription subscription) {
         this.event = event;
         this.subscription = subscription;
     }
 
-    static PendingPost obtainPendingPost(Subscription subscription, Object event) {
+    static PendingPost obtainPendingPost(ISubscription subscription, Object event) {
         synchronized (pendingPostPool) {
             int size = pendingPostPool.size();
             if (size > 0) {

--- a/EventBus/src/org/greenrobot/eventbus/Poster.java
+++ b/EventBus/src/org/greenrobot/eventbus/Poster.java
@@ -28,5 +28,5 @@ interface Poster {
      * @param subscription Subscription which will receive the event.
      * @param event        Event that will be posted to subscribers.
      */
-    void enqueue(Subscription subscription, Object event);
+    void enqueue(ISubscription subscription, Object event);
 }

--- a/EventBus/src/org/greenrobot/eventbus/Subscription.java
+++ b/EventBus/src/org/greenrobot/eventbus/Subscription.java
@@ -15,14 +15,34 @@
  */
 package org.greenrobot.eventbus;
 
-final class Subscription {
-    final Object subscriber;
-    final SubscriberMethod subscriberMethod;
+final class Subscription implements ISubscription {
+    private final Object subscriber;
+    private final SubscriberMethod subscriberMethod;
     /**
      * Becomes false as soon as {@link EventBus#unregister(Object)} is called, which is checked by queued event delivery
      * {@link EventBus#invokeSubscriber(PendingPost)} to prevent race conditions.
      */
-    volatile boolean active;
+    private volatile boolean active;
+
+    @Override
+    public Object getSubscriber() {
+        return subscriber;
+    }
+
+    @Override
+    public SubscriberMethod getSubscriberMethod() {
+        return subscriberMethod;
+    }
+
+    @Override
+    public boolean isActive() {
+        return active;
+    }
+
+    @Override
+    public void setIsActive(boolean isActive) {
+        this.active = isActive;
+    }
 
     Subscription(Object subscriber, SubscriberMethod subscriberMethod) {
         this.subscriber = subscriber;
@@ -32,10 +52,10 @@ final class Subscription {
 
     @Override
     public boolean equals(Object other) {
-        if (other instanceof Subscription) {
-            Subscription otherSubscription = (Subscription) other;
-            return subscriber == otherSubscription.subscriber
-                    && subscriberMethod.equals(otherSubscription.subscriberMethod);
+        if (other instanceof ISubscription) {
+            ISubscription otherSubscription = (ISubscription) other;
+            return subscriber == otherSubscription.getSubscriber()
+                    && subscriberMethod.equals(otherSubscription.getSubscriberMethod());
         } else {
             return false;
         }

--- a/EventBus/src/org/greenrobot/eventbus/WeakSubscription.java
+++ b/EventBus/src/org/greenrobot/eventbus/WeakSubscription.java
@@ -1,0 +1,64 @@
+package org.greenrobot.eventbus;
+
+import java.lang.ref.WeakReference;
+
+public class WeakSubscription extends WeakReference<Object> implements ISubscription {
+
+    private final SubscriberMethod subscriberMethod;
+
+    /**
+     * Becomes false as soon as {@link EventBus#unregister(Object)} is called, which is checked by queued event delivery
+     * {@link EventBus#invokeSubscriber(PendingPost)} to prevent race conditions.
+     */
+    private volatile boolean active;
+
+    WeakSubscription(Object subscriber, SubscriberMethod subscriberMethod) {
+        super(subscriber);
+        this.subscriberMethod = subscriberMethod;
+        active = true;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other instanceof ISubscription) {
+            ISubscription otherSubscription = (ISubscription) other;
+            return get() == otherSubscription.getSubscriber()
+                    && subscriberMethod.equals(otherSubscription.getSubscriberMethod());
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        // I have to admit that this kind of implementation could not guarantee thread safe.
+        // If the reference is being claimed when hashCode() executing, and the equals()
+        // might not behave in accordance with it. But it seems there is no better way.
+        Object referent = get();
+        if (referent != null) {
+            return referent.hashCode() + subscriberMethod.methodString.hashCode();
+        } else {
+            return System.identityHashCode(this) + subscriberMethod.methodString.hashCode();
+        }
+    }
+
+    @Override
+    public Object getSubscriber() {
+        return get();
+    }
+
+    @Override
+    public SubscriberMethod getSubscriberMethod() {
+        return subscriberMethod;
+    }
+
+    @Override
+    public boolean isActive() {
+        return active;
+    }
+
+    @Override
+    public void setIsActive(boolean isActive) {
+        this.active = isActive;
+    }
+}


### PR DESCRIPTION
we have been using this registerWeak function for a while and it runs steady, also reduce the chance to cause memory leak on android. sometimes it is really hard to find a proper place to call unregister.
Empty reference will be removed when new registration happens