### PR TITLE
Add id to subscribers

### DIFF
--- a/EventBus/src/org/greenrobot/eventbus/EventBus.java
+++ b/EventBus/src/org/greenrobot/eventbus/EventBus.java
@@ -443,8 +443,6 @@ public class EventBus {
     }
 
     private CopyOnWriteArrayList<Subscription> clearSubscriptionsById(CopyOnWriteArrayList<Subscription> subscriptions, Object id) {
-
-        Log.e(TAG, "clearSubscriptionsById: "+ subscriptions.size() );
         if (id == null){
             return  subscriptions;
         } else {

--- a/EventBus/src/org/greenrobot/eventbus/EventBus.java
+++ b/EventBus/src/org/greenrobot/eventbus/EventBus.java
@@ -15,6 +15,8 @@
  */
 package org.greenrobot.eventbus;
 
+import android.util.Log;
+
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -139,19 +141,23 @@ public class EventBus {
      * ThreadMode} and priority.
      */
     public void register(Object subscriber) {
+        register(subscriber, null);
+    }
+
+    public void register(Object subscriber, Object id) {
         Class<?> subscriberClass = subscriber.getClass();
         List<SubscriberMethod> subscriberMethods = subscriberMethodFinder.findSubscriberMethods(subscriberClass);
         synchronized (this) {
             for (SubscriberMethod subscriberMethod : subscriberMethods) {
-                subscribe(subscriber, subscriberMethod);
+                subscribe(id, subscriber, subscriberMethod);
             }
         }
     }
 
     // Must be called in synchronized block
-    private void subscribe(Object subscriber, SubscriberMethod subscriberMethod) {
+    private void subscribe(Object id, Object subscriber, SubscriberMethod subscriberMethod) {
         Class<?> eventType = subscriberMethod.eventType;
-        Subscription newSubscription = new Subscription(subscriber, subscriberMethod);
+        Subscription newSubscription = new Subscription(id, subscriber, subscriberMethod);
         CopyOnWriteArrayList<Subscription> subscriptions = subscriptionsByEventType.get(eventType);
         if (subscriptions == null) {
             subscriptions = new CopyOnWriteArrayList<>();
@@ -253,6 +259,10 @@ public class EventBus {
 
     /** Posts the given event to the event bus. */
     public void post(Object event) {
+        post(event, null);
+    }
+
+    public void post(Object event, Object id) {
         PostingThreadState postingState = currentPostingThreadState.get();
         List<Object> eventQueue = postingState.eventQueue;
         eventQueue.add(event);
@@ -265,7 +275,7 @@ public class EventBus {
             }
             try {
                 while (!eventQueue.isEmpty()) {
-                    postSingleEvent(eventQueue.remove(0), postingState);
+                    postSingleEvent(id, eventQueue.remove(0), postingState);
                 }
             } finally {
                 postingState.isPosting = false;
@@ -302,11 +312,15 @@ public class EventBus {
      * event of an event's type is kept in memory for future access by subscribers using {@link Subscribe#sticky()}.
      */
     public void postSticky(Object event) {
+        postSticky(event, null);
+    }
+
+    public void postSticky(Object event, Object id) {
         synchronized (stickyEvents) {
             stickyEvents.put(event.getClass(), event);
         }
         // Should be posted after it is putted, in case the subscriber wants to remove immediately
-        post(event);
+        post(event, id);
     }
 
     /**
@@ -376,7 +390,7 @@ public class EventBus {
         return false;
     }
 
-    private void postSingleEvent(Object event, PostingThreadState postingState) throws Error {
+    private void postSingleEvent(Object id, Object event, PostingThreadState postingState) throws Error {
         Class<?> eventClass = event.getClass();
         boolean subscriptionFound = false;
         if (eventInheritance) {
@@ -384,10 +398,10 @@ public class EventBus {
             int countTypes = eventTypes.size();
             for (int h = 0; h < countTypes; h++) {
                 Class<?> clazz = eventTypes.get(h);
-                subscriptionFound |= postSingleEventForEventType(event, postingState, clazz);
+                subscriptionFound |= postSingleEventForEventType(id, event, postingState, clazz);
             }
         } else {
-            subscriptionFound = postSingleEventForEventType(event, postingState, eventClass);
+            subscriptionFound = postSingleEventForEventType(id, event, postingState, eventClass);
         }
         if (!subscriptionFound) {
             if (logNoSubscriberMessages) {
@@ -400,12 +414,13 @@ public class EventBus {
         }
     }
 
-    private boolean postSingleEventForEventType(Object event, PostingThreadState postingState, Class<?> eventClass) {
+    private boolean postSingleEventForEventType(Object id, Object event, PostingThreadState postingState, Class<?> eventClass) {
         CopyOnWriteArrayList<Subscription> subscriptions;
         synchronized (this) {
             subscriptions = subscriptionsByEventType.get(eventClass);
         }
         if (subscriptions != null && !subscriptions.isEmpty()) {
+            subscriptions = clearSubscriptionsById(subscriptions, id);
             for (Subscription subscription : subscriptions) {
                 postingState.event = event;
                 postingState.subscription = subscription;
@@ -425,6 +440,22 @@ public class EventBus {
             return true;
         }
         return false;
+    }
+
+    private CopyOnWriteArrayList<Subscription> clearSubscriptionsById(CopyOnWriteArrayList<Subscription> subscriptions, Object id) {
+
+        Log.e(TAG, "clearSubscriptionsById: "+ subscriptions.size() );
+        if (id == null){
+            return  subscriptions;
+        } else {
+            CopyOnWriteArrayList<Subscription> result = new CopyOnWriteArrayList<>();
+            for (Subscription s : subscriptions) {
+                if (s.id == id) {
+                    result.add(s);
+                }
+            }
+            return result;
+        }
     }
 
     private void postToSubscription(Subscription subscription, Object event, boolean isMainThread) {

--- a/EventBus/src/org/greenrobot/eventbus/Subscription.java
+++ b/EventBus/src/org/greenrobot/eventbus/Subscription.java
@@ -16,6 +16,7 @@
 package org.greenrobot.eventbus;
 
 final class Subscription {
+    final Object id;
     final Object subscriber;
     final SubscriberMethod subscriberMethod;
     /**
@@ -24,7 +25,8 @@ final class Subscription {
      */
     volatile boolean active;
 
-    Subscription(Object subscriber, SubscriberMethod subscriberMethod) {
+    Subscription(Object id, Object subscriber, SubscriberMethod subscriberMethod) {
+        this.id = id;
         this.subscriber = subscriber;
         this.subscriberMethod = subscriberMethod;
         active = true;

--- a/EventBusTest/src/org/greenrobot/eventbus/EventBusPostByIdTest.java
+++ b/EventBusTest/src/org/greenrobot/eventbus/EventBusPostByIdTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2012-2016 Markus Junginger, greenrobot (http://greenrobot.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.greenrobot.eventbus;
+
+import static org.junit.Assert.assertEquals;
+
+import android.util.Log;
+
+import org.junit.Test;
+
+/**
+ * @author Emir Rahman Muhammadzadeh
+ */
+public class EventBusPostByIdTest extends AbstractAndroidEventBusTest {
+    @Test
+    public void testPostById() throws InterruptedException {
+
+        Object obj1 = new Object() {
+            @Subscribe(threadMode = ThreadMode.MAIN)
+            public void onEvent(String event) {
+                assertEquals("hello First Object", event);
+            }
+        };
+
+        Object obj2 = new Object() {
+            @Subscribe(threadMode = ThreadMode.MAIN)
+            public void onEvent(String event) {
+                assertEquals("hello Second Object", event);
+            }
+        };
+
+        Object obj3 = new Object() {
+            @Subscribe(threadMode = ThreadMode.MAIN)
+            public void onEvent(String event) {
+                assertEquals("hello Third Object", event);
+            }
+        };
+
+        eventBus.register(obj1, 1);
+        eventBus.register(obj2, 2);
+        eventBus.register(obj3, 3);
+
+
+        eventBus.post("hello First Object", 1);
+        eventBus.post("hello Second Object", 2);
+        eventBus.post("hello Third Object", 3);
+    }
+
+    @Test
+    public void testPostPublic() throws InterruptedException {
+
+        Object obj1 = new Object() {
+            @Subscribe(threadMode = ThreadMode.MAIN)
+            public void onEvent(String event) {
+                assertEquals("hello everybody", event);
+            }
+        };
+
+        Object obj2 = new Object() {
+            @Subscribe(threadMode = ThreadMode.MAIN)
+            public void onEvent(String event) {
+                assertEquals("hello everybody", event);
+            }
+        };
+
+        Object obj3 = new Object() {
+            @Subscribe(threadMode = ThreadMode.MAIN)
+            public void onEvent(String event) {
+                assertEquals("hello everybody", event);
+            }
+        };
+
+        eventBus.register(obj1, 1);
+        eventBus.register(obj2, 2);
+        eventBus.register(obj3, 3);
+
+        eventBus.post("hello everybody");
+
+    }
+
+}

--- a/EventBusTest/src/org/greenrobot/eventbus/EventBusPostByIdTest.java
+++ b/EventBusTest/src/org/greenrobot/eventbus/EventBusPostByIdTest.java
@@ -17,8 +17,6 @@ package org.greenrobot.eventbus;
 
 import static org.junit.Assert.assertEquals;
 
-import android.util.Log;
-
 import org.junit.Test;
 
 /**


### PR DESCRIPTION
Please consider the following scenario:
In Messenger, there is a list of chats that need to be updated. Therefore, this must happen by sending an event. The specified event is sent to all rows of chats by default. But we need to send the chat update event in only one row. In this case, the ID is used.
![Eventbus-by-id](https://user-images.githubusercontent.com/10474363/141925295-f2b165a1-e63a-4384-8d34-c584d0bea16b.png)


