### PR TITLE
Fix ThrowableFailureEvent ProGuard rule

### DIFF
--- a/EventBus/src/org/greenrobot/eventbus/util/AsyncExecutor.java
+++ b/EventBus/src/org/greenrobot/eventbus/util/AsyncExecutor.java
@@ -111,24 +111,21 @@ public class AsyncExecutor {
 
     /** Posts an failure event if the given {@link RunnableEx} throws an Exception. */
     public void execute(final RunnableEx runnable) {
-        threadPool.execute(new Runnable() {
-            @Override
-            public void run() {
+        threadPool.execute(() -> {
+            try {
+                runnable.run();
+            } catch (Exception e) {
+                Object event;
                 try {
-                    runnable.run();
-                } catch (Exception e) {
-                    Object event;
-                    try {
-                        event = failureEventConstructor.newInstance(e);
-                    } catch (Exception e1) {
-                        eventBus.getLogger().log(Level.SEVERE, "Original exception:", e);
-                        throw new RuntimeException("Could not create failure event", e1);
-                    }
-                    if (event instanceof HasExecutionScope) {
-                        ((HasExecutionScope) event).setExecutionScope(scope);
-                    }
-                    eventBus.post(event);
+                    event = failureEventConstructor.newInstance(e);
+                } catch (Exception e1) {
+                    eventBus.getLogger().log(Level.SEVERE, "Original exception:", e);
+                    throw new RuntimeException("Could not create failure event", e1);
                 }
+                if (event instanceof HasExecutionScope) {
+                    ((HasExecutionScope) event).setExecutionScope(scope);
+                }
+                eventBus.post(event);
             }
         });
     }

--- a/EventBus/src/org/greenrobot/eventbus/util/AsyncExecutor.java
+++ b/EventBus/src/org/greenrobot/eventbus/util/AsyncExecutor.java
@@ -23,10 +23,18 @@ import java.util.concurrent.Executors;
 import java.util.logging.Level;
 
 /**
- * Executes an {@link RunnableEx} using a thread pool. Thrown exceptions are propagated by posting failure events of any
- * given type (default is {@link ThrowableFailureEvent}).
- * 
- * @author Markus
+ * Executes an {@link RunnableEx} using a thread pool. Thrown exceptions are propagated by posting failure events.
+ * By default, uses {@link ThrowableFailureEvent}.
+ * <p>
+ * Set a custom event type using {@link Builder#failureEventType(Class)}.
+ * The failure event class must have a constructor with one parameter of type {@link Throwable}.
+ * If using ProGuard or R8 make sure the constructor of the failure event class is kept, it is accessed via reflection.
+ * E.g. add a rule like
+ * <pre>
+ * -keepclassmembers class com.example.CustomThrowableFailureEvent {
+ *     &lt;init&gt;(java.lang.Throwable);
+ * }
+ * </pre>
  */
 public class AsyncExecutor {
 

--- a/EventBus/src/org/greenrobot/eventbus/util/ThrowableFailureEvent.java
+++ b/EventBus/src/org/greenrobot/eventbus/util/ThrowableFailureEvent.java
@@ -17,6 +17,7 @@ package org.greenrobot.eventbus.util;
 
 /**
  * A generic failure event, which can be used by apps to propagate thrown exceptions.
+ * Used as default failure event by {@link AsyncExecutor}.
  */
 public class ThrowableFailureEvent implements HasExecutionScope {
     protected final Throwable throwable;

--- a/EventBusPerformance/build.gradle
+++ b/EventBusPerformance/build.gradle
@@ -40,4 +40,9 @@ android {
             }
         }
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }

--- a/eventbus-android/consumer-rules.pro
+++ b/eventbus-android/consumer-rules.pro
@@ -4,8 +4,9 @@
 }
 -keep enum org.greenrobot.eventbus.ThreadMode { *; }
 
-# And if you use AsyncExecutor:
--keepclassmembers class * extends org.greenrobot.eventbus.util.ThrowableFailureEvent {
+# If using AsyncExecutord, keep required constructor of default event used.
+# Adjust the class name if a custom failure event type is used.
+-keepclassmembers class org.greenrobot.eventbus.util.ThrowableFailureEvent {
     <init>(java.lang.Throwable);
 }
 


### PR DESCRIPTION
Closes #685 

- Change ProGuard rule for ThrowableFailureEvent to only apply to itself, not subclasses. (ThrowableFailureEvent is the default failure event type used by AsyncExecutor.) #685 