### PR TITLE
SubscriberMethodFinder field optimization.

### DIFF
--- a/EventBus/src/org/greenrobot/eventbus/SubscriberMethodFinder.java
+++ b/EventBus/src/org/greenrobot/eventbus/SubscriberMethodFinder.java
@@ -38,7 +38,7 @@ class SubscriberMethodFinder {
     private static final int MODIFIERS_IGNORE = Modifier.ABSTRACT | Modifier.STATIC | BRIDGE | SYNTHETIC;
     private static final Map<Class<?>, List<SubscriberMethod>> METHOD_CACHE = new ConcurrentHashMap<>();
 
-    private List<SubscriberInfoIndex> subscriberInfoIndexes;
+    private final List<SubscriberInfoIndex> subscriberInfoIndexes;
     private final boolean strictMethodVerification;
     private final boolean ignoreGeneratedIndex;
 


### PR DESCRIPTION
I found that there is subscriberInfoIndexes field in SubscriberMethodFinder that can be set to final,And I observe that this field is only assigned in the constructor,So I set this field to final.
I don't know if this modification is in line with your expectations.