### PR TITLE
fix the issue of Property priority not respected in sticky event

### DIFF
--- a/EventBus/src/org/greenrobot/eventbus/EventBus.java
+++ b/EventBus/src/org/greenrobot/eventbus/EventBus.java
@@ -18,6 +18,7 @@ package org.greenrobot.eventbus;
 import org.greenrobot.eventbus.android.AndroidDependenciesDetector;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -148,6 +149,7 @@ public class EventBus {
 
         Class<?> subscriberClass = subscriber.getClass();
         List<SubscriberMethod> subscriberMethods = subscriberMethodFinder.findSubscriberMethods(subscriberClass);
+        Collections.sort(subscriberMethods);
         synchronized (this) {
             for (SubscriberMethod subscriberMethod : subscriberMethods) {
                 subscribe(subscriber, subscriberMethod);

--- a/EventBus/src/org/greenrobot/eventbus/SubscriberMethod.java
+++ b/EventBus/src/org/greenrobot/eventbus/SubscriberMethod.java
@@ -18,7 +18,7 @@ package org.greenrobot.eventbus;
 import java.lang.reflect.Method;
 
 /** Used internally by EventBus and generated subscriber indexes. */
-public class SubscriberMethod {
+public class SubscriberMethod implements Comparable<SubscriberMethod>{
     final Method method;
     final ThreadMode threadMode;
     final Class<?> eventType;
@@ -64,5 +64,10 @@ public class SubscriberMethod {
     @Override
     public int hashCode() {
         return method.hashCode();
+    }
+
+    @Override
+    public int compareTo(SubscriberMethod subscriberMethod) {
+        return Integer.compare(subscriberMethod.priority,this.priority);
     }
 }

--- a/EventBusTestJava/src/main/java/org/greenrobot/eventbus/EventBusStickyEventTest.java
+++ b/EventBusTestJava/src/main/java/org/greenrobot/eventbus/EventBusStickyEventTest.java
@@ -24,6 +24,8 @@ import static org.junit.Assert.*;
  */
 public class EventBusStickyEventTest extends AbstractEventBusTest {
 
+    private int a = 0;
+
     @Test
     public void testPostSticky() throws InterruptedException {
         eventBus.postSticky("Sticky");
@@ -54,6 +56,14 @@ public class EventBusStickyEventTest extends AbstractEventBusTest {
 
         eventBus.postSticky(new IntTestEvent(8));
         assertEquals(6, eventCount.intValue());
+    }
+
+    @Test
+    public void testPostTwoDiffPriorityStickyEventOrder() throws InterruptedException {
+        eventBus.postSticky("Sticky");
+        eventBus.postSticky(1);
+        eventBus.register(new TwoDiffPriorityStickyEventSubscriber());
+        assertEquals(1, a);
     }
 
     @Test
@@ -184,6 +194,19 @@ public class EventBusStickyEventTest extends AbstractEventBusTest {
         @Subscribe
         public void onEvent(IntTestEvent event) {
             trackEvent(event);
+        }
+    }
+
+    public class TwoDiffPriorityStickyEventSubscriber {
+
+        @Subscribe(sticky = true,priority = 1)
+        public void onEvent(String event) {
+            a = 1;
+        }
+
+        @Subscribe(sticky = true,priority = 2)
+        public void onEvent(Integer event) {
+            a = 2;
         }
     }
 


### PR DESCRIPTION
fix the issue of Property "priority" not respected in sticky event #656 
reason of issue:the list subscriberMethods is not sorted by priority before postSticky
solution: sort the subscriberMethods by priority
ps:i add the testcase in EventBusStickyEventTest and it passed ... and all test case in EventBusTestJava and EventbusTest module are all passed
:)