### PR TITLE
add function of using javapoet to generate java files

### DIFF
--- a/EventBusAnnotationProcessor/build.gradle
+++ b/EventBusAnnotationProcessor/build.gradle
@@ -9,6 +9,7 @@ java.targetCompatibility = JavaVersion.VERSION_1_8
 dependencies {
     implementation project(':eventbus-java')
     implementation 'de.greenrobot:java-common:2.3.1'
+    implementation 'com.squareup:javapoet:1.13.0'
 
     // Generates the required META-INF descriptor to make the processor incremental.
     def incap = '0.2'

--- a/EventBusTest/build.gradle
+++ b/EventBusTest/build.gradle
@@ -27,8 +27,8 @@ android {
     compileSdkVersion _compileSdkVersion
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_7
-        targetCompatibility = JavaVersion.VERSION_1_7
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     sourceSets {


### PR DESCRIPTION
add function of using javapoet to generate java files #554 

benifits:
1. it is type safe, making it easier to refactor with.
2. it is more safe  because it will add  import automaticly
3. make code more elegent and easy to read by the thought of OOP
[1.txt](https://github.com/greenrobot/EventBus/files/11011565/1.txt)
[2.txt](https://github.com/greenrobot/EventBus/files/11011566/2.txt)
the files are the code generated by javapoet and Bufferwriter
I check the content they were same the all the test cases in TestModule has been passed :)