### PR TITLE
When virtual thread meets synchronized code block, it will pin the platform thread, so replace synchronized by ReentrantLock class.

### DIFF
--- a/EventBus/src/org/greenrobot/eventbus/EventBus.java
+++ b/EventBus/src/org/greenrobot/eventbus/EventBus.java
@@ -81,17 +81,20 @@ public class EventBus {
     private final int indexCount;
     private final Logger logger;
 
-    private final ReentrantLock lock = new ReentrantLock();
+    public static final ReentrantLock lock = new ReentrantLock();
 
     /** Convenience singleton for apps using a process-wide EventBus instance. */
     public static EventBus getDefault() {
         EventBus instance = defaultInstance;
         if (instance == null) {
-            synchronized (EventBus.class) {
+            lock.lock();
+            try {
                 instance = EventBus.defaultInstance;
                 if (instance == null) {
                     instance = EventBus.defaultInstance = new EventBus();
                 }
+            } finally {
+                lock.unlock();
             }
         }
         return instance;

--- a/EventBus/src/org/greenrobot/eventbus/EventBusBuilder.java
+++ b/EventBus/src/org/greenrobot/eventbus/EventBusBuilder.java
@@ -175,13 +175,16 @@ public class EventBusBuilder {
      * @throws EventBusException if there's already a default EventBus instance in place
      */
     public EventBus installDefaultEventBus() {
-        synchronized (EventBus.class) {
+        EventBus.lock.lock();
+        try {
             if (EventBus.defaultInstance != null) {
                 throw new EventBusException("Default instance already exists." +
                         " It may be only set once before it's used the first time to ensure consistent behavior.");
             }
             EventBus.defaultInstance = build();
             return EventBus.defaultInstance;
+        } finally {
+            EventBus.lock.unlock();
         }
     }
 


### PR DESCRIPTION
JEP 491 will be added in Java 24, which will be released on March 18, 2025. However, this version will not be used soon. Therefore, it is still worthwhile to replace synchronized with ReentrantLock in the virtual thread environment.