### PR TITLE
Add the ability to throw NoSubscriberException

### DIFF
--- a/EventBus/src/org/greenrobot/eventbus/EventBus.java
+++ b/EventBus/src/org/greenrobot/eventbus/EventBus.java
@@ -69,6 +69,7 @@ public class EventBus {
     private final ExecutorService executorService;
 
     private final boolean throwSubscriberException;
+    private final boolean throwNoSubscriberException;
     private final boolean logSubscriberExceptions;
     private final boolean logNoSubscriberMessages;
     private final boolean sendSubscriberExceptionEvent;
@@ -127,6 +128,7 @@ public class EventBus {
         sendSubscriberExceptionEvent = builder.sendSubscriberExceptionEvent;
         sendNoSubscriberEvent = builder.sendNoSubscriberEvent;
         throwSubscriberException = builder.throwSubscriberException;
+        throwNoSubscriberException = builder.throwNoSubscriberException;
         eventInheritance = builder.eventInheritance;
         executorService = builder.executorService;
     }
@@ -397,6 +399,9 @@ public class EventBus {
             subscriptionFound = postSingleEventForEventType(event, postingState, eventClass);
         }
         if (!subscriptionFound) {
+            if (throwNoSubscriberException) {
+                throw new EventBusException("No subscribers registered for event " + eventClass);
+            }
             if (logNoSubscriberMessages) {
                 logger.log(Level.FINE, "No subscribers registered for event " + eventClass);
             }

--- a/EventBus/src/org/greenrobot/eventbus/EventBusBuilder.java
+++ b/EventBus/src/org/greenrobot/eventbus/EventBusBuilder.java
@@ -15,12 +15,13 @@
  */
 package org.greenrobot.eventbus;
 
-import org.greenrobot.eventbus.android.AndroidComponents;
-import org.greenrobot.eventbus.meta.SubscriberInfoIndex;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
+import org.greenrobot.eventbus.android.AndroidComponents;
+import org.greenrobot.eventbus.meta.SubscriberInfoIndex;
 
 /**
  * Creates EventBus instances with custom parameters and also allows to install a custom default EventBus instance.
@@ -89,8 +90,6 @@ public class EventBusBuilder {
      * This is useful for critical events that must have a subscriber. For example, in startup scenarios
      * where bean registration hasn't completed yet, you might want to catch configuration errors early.
      * <p/>
-     * Tip: Use this with BuildConfig.DEBUG to let the app crash in DEBUG mode (only). In production,
-     * consider using {@link #sendNoSubscriberEvent(boolean)} to handle missing subscribers gracefully.
      */
     public EventBusBuilder throwNoSubscriberException(boolean throwNoSubscriberException) {
         this.throwNoSubscriberException = throwNoSubscriberException;

--- a/EventBus/src/org/greenrobot/eventbus/EventBusBuilder.java
+++ b/EventBus/src/org/greenrobot/eventbus/EventBusBuilder.java
@@ -35,6 +35,7 @@ public class EventBusBuilder {
     boolean sendSubscriberExceptionEvent = true;
     boolean sendNoSubscriberEvent = true;
     boolean throwSubscriberException;
+    boolean throwNoSubscriberException;
     boolean eventInheritance = true;
     boolean ignoreGeneratedIndex;
     boolean strictMethodVerification;
@@ -79,6 +80,20 @@ public class EventBusBuilder {
      */
     public EventBusBuilder throwSubscriberException(boolean throwSubscriberException) {
         this.throwSubscriberException = throwSubscriberException;
+        return this;
+    }
+
+    /**
+     * Fails if no subscriber is found for a posted event (default: false).
+     * <p/>
+     * This is useful for critical events that must have a subscriber. For example, in startup scenarios
+     * where bean registration hasn't completed yet, you might want to catch configuration errors early.
+     * <p/>
+     * Tip: Use this with BuildConfig.DEBUG to let the app crash in DEBUG mode (only). In production,
+     * consider using {@link #sendNoSubscriberEvent(boolean)} to handle missing subscribers gracefully.
+     */
+    public EventBusBuilder throwNoSubscriberException(boolean throwNoSubscriberException) {
+        this.throwNoSubscriberException = throwNoSubscriberException;
         return this;
     }
 


### PR DESCRIPTION
Fails if no subscriber is found for a posted event
This is useful for critical events that must have a subscriber. For example, in startup scenarios where bean registration hasn't completed yet, you might want to catch configuration errors early.